### PR TITLE
docs(adr): add architecture decision records baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@
 - PR template: `.github/pull_request_template.md`
 - Issue templates: `.github/ISSUE_TEMPLATE/`
 - Code ownership: `CODEOWNERS`
+
+## Architecture decisions
+
+- ADR index: `docs/adr/README.md`
+- Current accepted decisions:
+  - `docs/adr/0001-queue-system-strategy.md`
+  - `docs/adr/0002-database-split-postgres-clickhouse.md`
+  - `docs/adr/0003-workflow-orchestration-strategy.md`

--- a/docs/adr/0001-queue-system-strategy.md
+++ b/docs/adr/0001-queue-system-strategy.md
@@ -1,0 +1,54 @@
+# ADR-0001: Queue system strategy (NATS first)
+
+- **Status:** Accepted
+- **Date:** 2026-04-10
+- **Owners:** Platform team
+- **Decision scope:** Job dispatch and worker communication for genomics pipeline stages.
+
+## Context
+
+The platform needs asynchronous execution for pipeline stages (QC, alignment, variant calling), retries, and worker scaling. The initial team is small, so operational simplicity is a priority during MVP.
+
+## Decision
+
+Use **NATS** as the initial queue and messaging backbone for job dispatch and worker communication.
+
+## Alternatives considered
+
+1. **RabbitMQ**
+   - Pros: mature routing features, strong queue semantics.
+   - Cons: higher operational overhead for current team size.
+2. **Kafka**
+   - Pros: durable event streams at large scale.
+   - Cons: heavy operational complexity for MVP workload.
+3. **Redis streams**
+   - Pros: simple for small systems.
+   - Cons: less aligned with long-term eventing and multi-consumer topology needs.
+
+## Trade-offs
+
+- **Gain:** fast implementation, low operational burden, straightforward local development with Docker.
+- **Cost:** fewer advanced stream-processing patterns than Kafka.
+- **Constraint:** needs deliberate retry/dead-letter design in application layer.
+
+## Risks
+
+- Message handling bugs may cause duplicate work or unacked jobs.
+- Insufficient observability could hide queue backlogs until late.
+
+## Mitigations
+
+- Enforce explicit ack/retry/dead-letter behavior per job type.
+- Add queue depth, retry count, and processing latency metrics.
+- Build idempotency in worker stages (safe re-processing).
+
+## Migration path
+
+1. Keep queue interactions behind a `queue` interface in Go.
+2. Separate message contracts from transport implementation.
+3. Add adapter for future Kafka/RabbitMQ backend when scale or compliance requires.
+4. Run dual-publish shadow mode before full transport cutover.
+
+## Consequences
+
+NATS is the default queue for MVP and early production-like environments. Future migration remains possible without redesigning business logic if transport boundaries are respected.

--- a/docs/adr/0002-database-split-postgres-clickhouse.md
+++ b/docs/adr/0002-database-split-postgres-clickhouse.md
@@ -1,0 +1,62 @@
+# ADR-0002: Database split (PostgreSQL + ClickHouse)
+
+- **Status:** Accepted
+- **Date:** 2026-04-10
+- **Owners:** Platform team
+- **Decision scope:** Persistence strategy for metadata and analytical genomic variants.
+
+## Context
+
+The platform stores two distinct data shapes:
+
+- transactional metadata (jobs, statuses, users, pipeline state)
+- analytical variant data (high-volume query workloads by gene/chromosome/position)
+
+A single database for both concerns would create pressure between OLTP and analytical access patterns.
+
+## Decision
+
+Adopt a **split-database architecture**:
+
+- **PostgreSQL** for transactional metadata and control-plane state.
+- **ClickHouse** for variant analytics and large-scale query workloads.
+
+## Alternatives considered
+
+1. **PostgreSQL only**
+   - Pros: one datastore, simpler initial setup.
+   - Cons: analytical workloads may degrade transactional reliability at scale.
+2. **ClickHouse only**
+   - Pros: strong analytical performance.
+   - Cons: weak fit for transactional workflow orchestration and strict row-level updates.
+3. **Elasticsearch for analytics + Postgres for metadata**
+   - Pros: flexible search.
+   - Cons: added indexing complexity and less direct fit for numeric analytical scans.
+
+## Trade-offs
+
+- **Gain:** each datastore is used for the workload it handles best.
+- **Cost:** added operational complexity and ETL/load pipeline between workflow outputs and analytics store.
+- **Constraint:** requires clear ownership boundaries to avoid data-model drift.
+
+## Risks
+
+- Data consistency lag between pipeline completion and query availability.
+- Schema evolution mismatch between transactional and analytical layers.
+
+## Mitigations
+
+- Define canonical variant ingestion contract and version it.
+- Track ingestion lag and failure metrics.
+- Apply migration discipline for both Postgres and ClickHouse schemas.
+
+## Migration path
+
+1. Start with minimal schemas for jobs (Postgres) and variants (ClickHouse).
+2. Add ingestion loader with idempotent upsert/dedup semantics.
+3. Introduce schema versioning and compatibility checks.
+4. If needed, add data lake/object-store layer later without changing control-plane model.
+
+## Consequences
+
+The system gains strong query performance and cleaner domain separation at the cost of integration complexity. This is acceptable for platform goals and expected data growth.

--- a/docs/adr/0003-workflow-orchestration-strategy.md
+++ b/docs/adr/0003-workflow-orchestration-strategy.md
@@ -1,0 +1,63 @@
+# ADR-0003: Workflow orchestration strategy (custom worker queue first)
+
+- **Status:** Accepted
+- **Date:** 2026-04-10
+- **Owners:** Platform team
+- **Decision scope:** How pipeline stages are orchestrated from MVP to scale-up.
+
+## Context
+
+The platform executes multi-stage genomic workflows with dependencies:
+
+1. QC (FastQC)
+2. Alignment (BWA + SAMtools)
+3. Variant calling (GATK)
+
+MVP requires fast iteration and full visibility into stage behavior. Later phases may need richer scheduling and DAG-level controls.
+
+## Decision
+
+Use a **custom Go worker orchestration model** for MVP, backed by queue messages and explicit stage-state tracking in Postgres.
+
+Design orchestration boundaries so the system can migrate to **Argo Workflows** or **Apache Airflow** when complexity or scale warrants.
+
+## Alternatives considered
+
+1. **Argo Workflows from day one**
+   - Pros: strong DAG orchestration, cloud-native scaling.
+   - Cons: high upfront complexity for MVP.
+2. **Apache Airflow from day one**
+   - Pros: mature scheduling and ecosystem.
+   - Cons: heavier operational footprint and Python-centric orchestration stack.
+3. **Pure shell-script orchestration**
+   - Pros: fastest initial scripting.
+   - Cons: poor reliability, observability, and maintainability for growth.
+
+## Trade-offs
+
+- **Gain:** rapid implementation and high control over execution semantics.
+- **Cost:** custom orchestration logic must be maintained.
+- **Constraint:** careful interface design is needed to avoid migration lock-in.
+
+## Risks
+
+- Orchestrator code could grow into brittle, implicit workflow logic.
+- Retry/checkpoint semantics may become inconsistent across stages.
+
+## Mitigations
+
+- Enforce explicit stage contracts (inputs, outputs, exit semantics).
+- Use a state machine model for valid transitions.
+- Add checkpoint metadata and idempotent stage execution rules.
+- Keep workflow definitions config-driven where possible.
+
+## Migration path
+
+1. Introduce `workflow_engine` interface and adapter boundary.
+2. Externalize workflow definitions to declarative config.
+3. Mirror one production workflow in Argo/Airflow as a pilot.
+4. Cut over workflow-by-workflow with validation parity checks.
+
+## Consequences
+
+The project can ship MVP quickly with full control while preserving a credible path to enterprise orchestration platforms.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records (ADR)
 
-This directory contains architecture decision records for the senju Genomic Data Processing & Variant Analysis Platform.
+This directory contains architecture decision records for senju.
 
 ## Status legend
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records (ADR)
 
-This directory contains architecture decision records for the Genomic Data Platform.
+This directory contains architecture decision records for the senju Genomic Data Processing & Variant Analysis Platform.
 
 ## Status legend
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records (ADR)
+
+This directory contains architecture decision records for the Genomic Data Platform.
+
+## Status legend
+
+- `Proposed`: under review, not yet approved for implementation.
+- `Accepted`: approved and expected for current implementation.
+- `Superseded`: replaced by a newer ADR.
+
+## ADR index
+
+- [ADR-0001: Queue system strategy (NATS first)](./0001-queue-system-strategy.md) - `Accepted`
+- [ADR-0002: Database split (PostgreSQL + ClickHouse)](./0002-database-split-postgres-clickhouse.md) - `Accepted`
+- [ADR-0003: Workflow orchestration strategy (custom worker queue first)](./0003-workflow-orchestration-strategy.md) - `Accepted`


### PR DESCRIPTION
This pull request introduces a new architecture decision record (ADR) process for the project, adds an ADR index, and documents three key architectural decisions regarding queue system selection, database architecture, and workflow orchestration. The changes improve project transparency and provide clear guidance for future technical decisions.

**Architecture Decision Record (ADR) process and documentation:**

* Added an ADR index and status legend in `docs/adr/README.md` to track and summarize major technical decisions.
* Updated `README.md` to include a section referencing the ADR index and current accepted decisions for easier discoverability.

**Documented architectural decisions:**

* Added `docs/adr/0001-queue-system-strategy.md` detailing the choice of NATS as the initial queue system, including rationale, alternatives, trade-offs, risks, and migration path.
* Added `docs/adr/0002-database-split-postgres-clickhouse.md` documenting the decision to use PostgreSQL for transactional data and ClickHouse for analytics, with discussion of alternatives and integration challenges.
* Added `docs/adr/0003-workflow-orchestration-strategy.md` describing the initial use of a custom Go worker orchestration model with a migration path to Argo Workflows or Apache Airflow in the future.