### PR TITLE
feat(api): FASTQ upload metadata API

### DIFF
--- a/backend/cmd/api/run.go
+++ b/backend/cmd/api/run.go
@@ -15,10 +15,13 @@ import (
 	"github.com/AminN77/senju/backend/internal/config"
 	"github.com/AminN77/senju/backend/internal/healthcheck"
 	"github.com/AminN77/senju/backend/internal/httpserver"
+	"github.com/AminN77/senju/backend/internal/job"
+	jobpostgres "github.com/AminN77/senju/backend/internal/job/postgres"
 	"github.com/AminN77/senju/backend/internal/platform/logging"
 	"github.com/AminN77/senju/backend/internal/platform/metrics"
 	"github.com/AminN77/senju/backend/internal/probe/httpget"
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
 )
 
@@ -47,7 +50,24 @@ func run() error {
 		return err
 	}
 	promRegistry := metrics.NewRegistry()
-	engine := newEngine(log, runner, versionInfo(), promRegistry)
+
+	var jobRepo job.Repository
+	var pgPool *pgxpool.Pool
+	if cfg.PostgresDSN != "" {
+		pool, err := pgxpool.New(context.Background(), cfg.PostgresDSN)
+		if err != nil {
+			return fmt.Errorf("postgres pool: %w", err)
+		}
+		pgPool = pool
+		jobRepo = jobpostgres.NewRepository(pool)
+	}
+	defer func() {
+		if pgPool != nil {
+			pgPool.Close()
+		}
+	}()
+
+	engine := newEngine(log, runner, versionInfo(), promRegistry, jobRepo)
 	addr := listenAddr(cfg.APIPort)
 
 	srv := &http.Server{
@@ -113,7 +133,7 @@ func listenAddr(port int) string {
 	return ":" + strconv.Itoa(port)
 }
 
-func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry) *gin.Engine {
+func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry, jobs job.Repository) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(httpserver.RequestLogger(log))
@@ -122,6 +142,7 @@ func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver ht
 		Version:         ver,
 		EnableSwaggerUI: gin.Mode() != gin.ReleaseMode,
 		Metrics:         prom.Handler(),
+		Jobs:            jobs,
 	})
 	return r
 }

--- a/backend/internal/api/fastqupload/handler.go
+++ b/backend/internal/api/fastqupload/handler.go
@@ -2,8 +2,10 @@
 package fastqupload
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -101,13 +103,19 @@ func handleCreate(repo job.Repository) gin.HandlerFunc {
 var errTrailingJSON = errors.New("trailing json")
 
 func decodeRequest(c *gin.Context) (Request, error) {
-	var req Request
-	dec := json.NewDecoder(c.Request.Body)
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return Request{}, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.DisallowUnknownFields()
+	var req Request
 	if err := dec.Decode(&req); err != nil {
 		return req, err
 	}
-	if dec.More() {
+	// Decoder.More() is for arrays/objects, not extra top-level values; use input offset.
+	rest := bytes.TrimSpace(body[dec.InputOffset():])
+	if len(rest) > 0 {
 		return req, errTrailingJSON
 	}
 	return req, nil
@@ -126,11 +134,12 @@ func validateRequest(req Request) []problem.FieldError {
 		{"r1_uri", req.R1URI},
 		{"r2_uri", req.R2URI},
 	} {
-		if strings.TrimSpace(pair.raw) == "" {
+		normalized := strings.TrimSpace(pair.raw)
+		if normalized == "" {
 			errs = append(errs, problem.FieldError{Field: pair.field, Message: "required"})
 			continue
 		}
-		if _, err := validateHTTPOrObjectURI(pair.raw); err != nil {
+		if _, err := validateHTTPOrObjectURI(normalized); err != nil {
 			errs = append(errs, problem.FieldError{Field: pair.field, Message: "invalid_uri"})
 		}
 	}

--- a/backend/internal/api/fastqupload/handler.go
+++ b/backend/internal/api/fastqupload/handler.go
@@ -1,0 +1,180 @@
+// Package fastqupload registers the FASTQ upload metadata HTTP API.
+package fastqupload
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/job"
+	"github.com/gin-gonic/gin"
+)
+
+// StageFastqUploadQueued is the initial pipeline stage for a FASTQ metadata job row.
+const StageFastqUploadQueued = "fastq_upload_queued"
+
+// Request is the JSON body for POST .../fastq-upload/metadata (paired-end MVP).
+type Request struct {
+	SampleID  string  `json:"sample_id"`
+	R1URI     string  `json:"r1_uri"`
+	R2URI     string  `json:"r2_uri"`
+	LibraryID *string `json:"library_id,omitempty"`
+	Platform  *string `json:"platform,omitempty"`
+	Notes     *string `json:"notes,omitempty"`
+}
+
+// CreateResponse is returned on 201 Created.
+type CreateResponse struct {
+	JobID string `json:"job_id"`
+}
+
+// Register mounts POST /fastq-upload/metadata on the given /v1/jobs group.
+// If repo is nil, the handler returns 503 (database not configured).
+func Register(g *gin.RouterGroup, repo job.Repository) {
+	if repo == nil {
+		g.POST("/fastq-upload/metadata", handleNoDatabase)
+		return
+	}
+	g.POST("/fastq-upload/metadata", handleCreate(repo))
+}
+
+func handleNoDatabase(c *gin.Context) {
+	problem.ServiceUnavailable(c, "Job persistence is not available; set POSTGRES_DSN or POSTGRES_HOST with credentials.")
+}
+
+func handleCreate(repo job.Repository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		req, err := decodeRequest(c)
+		if err != nil {
+			var synErr *json.SyntaxError
+			if errors.As(err, &synErr) {
+				problem.MalformedJSON(c, "invalid JSON syntax")
+				return
+			}
+			if errors.Is(err, errTrailingJSON) {
+				problem.MalformedJSON(c, "trailing JSON content")
+				return
+			}
+			if strings.Contains(err.Error(), "unknown field") {
+				problem.MalformedJSON(c, "unknown JSON field")
+				return
+			}
+			problem.MalformedJSON(c, "could not read request body")
+			return
+		}
+
+		fieldErrs := validateRequest(req)
+		if len(fieldErrs) > 0 {
+			problem.Validation(c, "one or more fields failed validation", fieldErrs)
+			return
+		}
+
+		input, err := canonicalInputJSON(req)
+		if err != nil {
+			problem.MalformedJSON(c, "could not build job payload")
+			return
+		}
+
+		j, err := repo.Create(c.Request.Context(), job.CreateParams{
+			Status:    job.StatusPending,
+			Stage:     StageFastqUploadQueued,
+			InputRef:  input,
+			OutputRef: nil,
+		})
+		if err != nil {
+			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
+				Type:   problem.TypeInternalError,
+				Title:  "Internal error",
+				Status: http.StatusInternalServerError,
+				Detail: "could not persist job",
+			})
+			return
+		}
+
+		c.JSON(http.StatusCreated, CreateResponse{JobID: j.ID.String()})
+	}
+}
+
+var errTrailingJSON = errors.New("trailing json")
+
+func decodeRequest(c *gin.Context) (Request, error) {
+	var req Request
+	dec := json.NewDecoder(c.Request.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		return req, err
+	}
+	if dec.More() {
+		return req, errTrailingJSON
+	}
+	return req, nil
+}
+
+func validateRequest(req Request) []problem.FieldError {
+	var errs []problem.FieldError
+	sid := strings.TrimSpace(req.SampleID)
+	if sid == "" {
+		errs = append(errs, problem.FieldError{Field: "sample_id", Message: "required"})
+	}
+	for _, pair := range []struct {
+		field string
+		raw   string
+	}{
+		{"r1_uri", req.R1URI},
+		{"r2_uri", req.R2URI},
+	} {
+		if strings.TrimSpace(pair.raw) == "" {
+			errs = append(errs, problem.FieldError{Field: pair.field, Message: "required"})
+			continue
+		}
+		if _, err := validateHTTPOrObjectURI(pair.raw); err != nil {
+			errs = append(errs, problem.FieldError{Field: pair.field, Message: "invalid_uri"})
+		}
+	}
+	return errs
+}
+
+func validateHTTPOrObjectURI(s string) (*url.URL, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, errors.New("missing scheme or host")
+	}
+	scheme := strings.ToLower(u.Scheme)
+	switch scheme {
+	case "http", "https":
+		return u, nil
+	case "s3", "s3a", "gs":
+		key := strings.Trim(strings.TrimPrefix(u.Path, "/"), "/")
+		if key == "" {
+			return nil, errors.New("object key required")
+		}
+		return u, nil
+	default:
+		return nil, errors.New("unsupported scheme")
+	}
+}
+
+func canonicalInputJSON(req Request) (json.RawMessage, error) {
+	canon := map[string]any{
+		"kind":      "fastq_upload_v1",
+		"sample_id": strings.TrimSpace(req.SampleID),
+		"r1_uri":    strings.TrimSpace(req.R1URI),
+		"r2_uri":    strings.TrimSpace(req.R2URI),
+	}
+	if req.LibraryID != nil && strings.TrimSpace(*req.LibraryID) != "" {
+		canon["library_id"] = strings.TrimSpace(*req.LibraryID)
+	}
+	if req.Platform != nil && strings.TrimSpace(*req.Platform) != "" {
+		canon["platform"] = strings.TrimSpace(*req.Platform)
+	}
+	if req.Notes != nil && strings.TrimSpace(*req.Notes) != "" {
+		canon["notes"] = strings.TrimSpace(*req.Notes)
+	}
+	return json.Marshal(canon)
+}

--- a/backend/internal/api/fastqupload/handler_test.go
+++ b/backend/internal/api/fastqupload/handler_test.go
@@ -1,0 +1,185 @@
+package fastqupload
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/job/stub"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func TestPostFastqMetadata_201(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":"https://example.com/r1.fq.gz","r2_uri":"https://example.com/r2.fq.gz"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	id, ok := got["job_id"].(string)
+	if !ok || id == "" {
+		t.Fatalf("job_id: %v", got)
+	}
+}
+
+func TestPostFastqMetadata_503_NoRepository(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), nil)
+
+	body := `{"sample_id":"S1","r1_uri":"https://a/x","r2_uri":"https://a/y"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestPostFastqMetadata_400_Validation(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"","r1_uri":"not-a-uri","r2_uri":"https://example.com/ok"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", w.Code)
+	}
+	var p problem.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Type != problem.TypeValidationError {
+		t.Fatalf("type %q", p.Type)
+	}
+	if len(p.Errors) < 2 {
+		t.Fatalf("errors: %+v", p.Errors)
+	}
+	// Deterministic order: field name ascending
+	for i := 1; i < len(p.Errors); i++ {
+		if p.Errors[i].Field < p.Errors[i-1].Field {
+			t.Fatalf("errors not sorted: %+v", p.Errors)
+		}
+	}
+}
+
+func TestPostFastqMetadata_400_UnknownField(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":"https://a/x","r2_uri":"https://a/y","extra":1}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestPostFastqMetadata_400_TrailingJSON(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":"https://a/x","r2_uri":"https://a/y"}`
+	body += `{"more":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPostFastqMetadata_S3URI(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":"s3://bucket/path/r1.fq","r2_uri":"s3://bucket/path/r2.fq"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPostFastqMetadata_S3URI_EmptyKey(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":"s3://bucket/","r2_uri":"http://x/y"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestPostFastqMetadata_OptionalFieldsStored(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	st := stub.New()
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), st)
+
+	body := `{"sample_id":"S1","r1_uri":"https://a/r1","r2_uri":"https://a/r2","library_id":"lib-1","platform":"ILLUMINA","notes":"qc ok"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status %d", w.Code)
+	}
+	var resp CreateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	id, err := uuid.Parse(resp.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, err := st.GetByID(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(j.InputRef, []byte(`"library_id"`)) {
+		t.Fatalf("input_ref: %s", j.InputRef)
+	}
+}

--- a/backend/internal/api/fastqupload/handler_test.go
+++ b/backend/internal/api/fastqupload/handler_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/job"
 	"github.com/AminN77/senju/backend/internal/job/stub"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -36,6 +38,44 @@ func TestPostFastqMetadata_201(t *testing.T) {
 	id, ok := got["job_id"].(string)
 	if !ok || id == "" {
 		t.Fatalf("job_id: %v", got)
+	}
+}
+
+// failingRepo always errors on Create to assert 500 problem+json contract.
+type failingRepo struct{}
+
+func (failingRepo) Create(context.Context, job.CreateParams) (*job.Job, error) {
+	return nil, errors.New("injected persistence failure")
+}
+
+func (failingRepo) GetByID(context.Context, uuid.UUID) (*job.Job, error) {
+	return nil, job.ErrNotFound
+}
+
+func (failingRepo) Update(context.Context, uuid.UUID, job.UpdateParams) (*job.Job, error) {
+	return nil, job.ErrNotFound
+}
+
+func TestPostFastqMetadata_500_RepositoryError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), failingRepo{})
+
+	body := `{"sample_id":"S1","r1_uri":"https://a/x","r2_uri":"https://a/y"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var p problem.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Type != problem.TypeInternalError {
+		t.Fatalf("type %q", p.Type)
 	}
 }
 
@@ -116,6 +156,22 @@ func TestPostFastqMetadata_400_TrailingJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPostFastqMetadata_URIWhitespaceTrimmed(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	body := `{"sample_id":"S1","r1_uri":" s3://bucket/k/r1 ","r2_uri":"s3://bucket/k/r2"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/metadata", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
 		t.Fatalf("status %d body %s", w.Code, w.Body.String())
 	}
 }

--- a/backend/internal/api/problem/problem.go
+++ b/backend/internal/api/problem/problem.go
@@ -1,0 +1,70 @@
+// Package problem provides RFC 7807-style JSON error bodies for HTTP APIs.
+package problem
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Well-known problem type URIs (stable identifiers; not necessarily resolvable).
+const (
+	TypeValidationError = "https://github.com/AminN77/senju/problems/validation-error"
+	TypeMalformedJSON   = "https://github.com/AminN77/senju/problems/malformed-json"
+	TypeServiceDisabled = "https://github.com/AminN77/senju/problems/service-unavailable"
+	TypeInternalError   = "https://github.com/AminN77/senju/problems/internal-error"
+)
+
+// Problem is an application/problem+json response (RFC 7807 profile).
+type Problem struct {
+	Type   string       `json:"type"`
+	Title  string       `json:"title"`
+	Status int          `json:"status"`
+	Detail string       `json:"detail,omitempty"`
+	Errors []FieldError `json:"errors,omitempty"`
+}
+
+// FieldError is a single validation failure with stable machine-oriented messaging.
+type FieldError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+// JSON writes a problem+json response with the given HTTP status.
+func JSON(c *gin.Context, status int, p Problem) {
+	c.Header("Content-Type", "application/problem+json; charset=utf-8")
+	c.JSON(status, p)
+}
+
+// Validation writes a deterministic validation error (errors sorted by field).
+func Validation(c *gin.Context, detail string, errs []FieldError) {
+	sort.Slice(errs, func(i, j int) bool { return errs[i].Field < errs[j].Field })
+	JSON(c, http.StatusBadRequest, Problem{
+		Type:   TypeValidationError,
+		Title:  "Validation failed",
+		Status: http.StatusBadRequest,
+		Detail: detail,
+		Errors: errs,
+	})
+}
+
+// MalformedJSON writes 400 for JSON parse / unknown field issues.
+func MalformedJSON(c *gin.Context, detail string) {
+	JSON(c, http.StatusBadRequest, Problem{
+		Type:   TypeMalformedJSON,
+		Title:  "Malformed JSON",
+		Status: http.StatusBadRequest,
+		Detail: detail,
+	})
+}
+
+// ServiceUnavailable writes 503 when an optional backend (e.g. Postgres) is not configured.
+func ServiceUnavailable(c *gin.Context, detail string) {
+	JSON(c, http.StatusServiceUnavailable, Problem{
+		Type:   TypeServiceDisabled,
+		Title:  "Service unavailable",
+		Status: http.StatusServiceUnavailable,
+		Detail: detail,
+	})
+}

--- a/backend/internal/api/problem/problem.go
+++ b/backend/internal/api/problem/problem.go
@@ -39,7 +39,12 @@ func JSON(c *gin.Context, status int, p Problem) {
 
 // Validation writes a deterministic validation error (errors sorted by field).
 func Validation(c *gin.Context, detail string, errs []FieldError) {
-	sort.Slice(errs, func(i, j int) bool { return errs[i].Field < errs[j].Field })
+	sort.SliceStable(errs, func(i, j int) bool {
+		if errs[i].Field != errs[j].Field {
+			return errs[i].Field < errs[j].Field
+		}
+		return errs[i].Message < errs[j].Message
+	})
 	JSON(c, http.StatusBadRequest, Problem{
 		Type:   TypeValidationError,
 		Title:  "Validation failed",

--- a/backend/internal/httpserver/router.go
+++ b/backend/internal/httpserver/router.go
@@ -10,7 +10,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/AminN77/senju/backend/internal/api/fastqupload"
 	"github.com/AminN77/senju/backend/internal/healthcheck"
+	"github.com/AminN77/senju/backend/internal/job"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
@@ -29,6 +31,8 @@ type Options struct {
 	EnableSwaggerUI bool
 	// Metrics exposes Prometheus text exposition at GET /metrics (required; use platform/metrics Registry.Handler() in production).
 	Metrics http.Handler
+	// Jobs persists job metadata. If nil, FASTQ metadata routes return 503 (database not configured).
+	Jobs job.Repository
 }
 
 // VersionInfo is returned by GET /version.
@@ -53,6 +57,7 @@ func Register(r *gin.Engine, opts Options) {
 	r.GET("/version", handleVersion(opts.Version))
 	r.GET("/", handleRoot)
 	r.GET("/metrics", gin.WrapH(opts.Metrics))
+	fastqupload.Register(r.Group("/v1/jobs"), opts.Jobs)
 	registerOpenAPISpecRoute(r)
 	if opts.EnableSwaggerUI {
 		registerSwaggerUIRoute(r)

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -159,6 +159,7 @@ components:
           type: string
     FastqUploadMetadataRequest:
       type: object
+      additionalProperties: false
       required:
         - sample_id
         - r1_uri
@@ -166,12 +167,15 @@ components:
       properties:
         sample_id:
           type: string
-          description: Sample identifier for this ingestion job.
+          minLength: 1
+          description: Sample identifier for this ingestion job (whitespace-only rejected by handler).
         r1_uri:
           type: string
+          minLength: 1
           description: URI for read 1 (forward) — http(s), s3, or gs.
         r2_uri:
           type: string
+          minLength: 1
           description: URI for read 2 (reverse) — http(s), s3, or gs.
         library_id:
           type: string

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -18,6 +18,8 @@ tags:
     description: Liveness and readiness probes for orchestration
   - name: Observability
     description: Prometheus metrics for monitoring
+  - name: Ingestion
+    description: Genomic ingestion job metadata (e.g. FASTQ upload tracking)
 paths:
   /:
     get:
@@ -96,6 +98,46 @@ paths:
             text/plain:
               schema:
                 type: string
+  /v1/jobs/fastq-upload/metadata:
+    post:
+      tags:
+        - Ingestion
+      summary: Register FASTQ upload metadata
+      description: |
+        Validates paired-end FASTQ ingestion metadata and persists a `jobs` row (`stage=fastq_upload_queued`).
+        Requires PostgreSQL to be configured; otherwise returns 503.
+      operationId: postFastqUploadMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FastqUploadMetadataRequest"
+      responses:
+        "201":
+          description: Job created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FastqUploadMetadataResponse"
+        "400":
+          description: Malformed JSON or validation failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "500":
+          description: Persistence failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "503":
+          description: Database not configured
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
 components:
   schemas:
     VersionInfo:
@@ -115,3 +157,64 @@ components:
           type: string
         build_time:
           type: string
+    FastqUploadMetadataRequest:
+      type: object
+      required:
+        - sample_id
+        - r1_uri
+        - r2_uri
+      properties:
+        sample_id:
+          type: string
+          description: Sample identifier for this ingestion job.
+        r1_uri:
+          type: string
+          description: URI for read 1 (forward) — http(s), s3, or gs.
+        r2_uri:
+          type: string
+          description: URI for read 2 (reverse) — http(s), s3, or gs.
+        library_id:
+          type: string
+        platform:
+          type: string
+        notes:
+          type: string
+    FastqUploadMetadataResponse:
+      type: object
+      required:
+        - job_id
+      properties:
+        job_id:
+          type: string
+          format: uuid
+    FieldError:
+      type: object
+      required:
+        - field
+        - message
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+          description: Stable code such as required or invalid_uri.
+    ProblemDetails:
+      type: object
+      required:
+        - type
+        - title
+        - status
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/FieldError"

--- a/backend/openapi/spec_test.go
+++ b/backend/openapi/spec_test.go
@@ -16,7 +16,7 @@ func TestSpecLoadsAndValidates(t *testing.T) {
 	if err := doc.Validate(loader.Context); err != nil {
 		t.Fatalf("validate openapi: %v", err)
 	}
-	paths := []string{"/", "/health/live", "/health/ready", "/version", "/metrics"}
+	paths := []string{"/", "/health/live", "/health/ready", "/version", "/metrics", "/v1/jobs/fastq-upload/metadata"}
 	for _, p := range paths {
 		if doc.Paths == nil || doc.Paths.Find(p) == nil {
 			t.Errorf("missing path %q in OpenAPI spec", p)

--- a/docs/api/fastq-upload.md
+++ b/docs/api/fastq-upload.md
@@ -1,0 +1,49 @@
+# FASTQ upload metadata API
+
+Registers **paired-end FASTQ ingestion metadata** so the platform can create a `jobs` row before actual file transfer or pipeline execution. Implemented for [Issue #6](https://github.com/AminN77/senju/issues/6).
+
+## Prerequisites
+
+- API process configured with PostgreSQL (`POSTGRES_DSN` or `POSTGRES_HOST` + credentials).
+- Schema applied: run migrations (see [docs/setup.md](../setup.md#database-migrations)).
+
+## Endpoint
+
+- **POST** `/v1/jobs/fastq-upload/metadata`
+- **Content-Type:** `application/json`
+
+### Request body (required fields)
+
+| Field       | Description                                      |
+|------------|--------------------------------------------------|
+| `sample_id` | Sample identifier                               |
+| `r1_uri`    | URI for read 1 (e.g. `https://...`, `s3://bucket/key/...`) |
+| `r2_uri`    | URI for read 2                                 |
+
+Optional: `library_id`, `platform`, `notes` (non-empty strings are stored in the job `input_ref` JSON).
+
+### Success (201)
+
+```json
+{ "job_id": "550e8400-e29b-41d4-a716-446655440000" }
+```
+
+### Errors
+
+- **400** `application/problem+json` — malformed JSON, unknown fields, or validation failures (`errors[]` sorted by `field`).
+- **503** — database not configured for the API process.
+
+## Example
+
+```bash
+curl -sS -X POST "http://localhost:${API_PORT:-8080}/v1/jobs/fastq-upload/metadata" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sample_id": "SAMPLE01",
+    "r1_uri": "s3://my-bucket/run1/R1.fq.gz",
+    "r2_uri": "s3://my-bucket/run1/R2.fq.gz",
+    "library_id": "LIB-001"
+  }'
+```
+
+OpenAPI: [backend/openapi/openapi.yaml](../../backend/openapi/openapi.yaml).

--- a/docs/api/fastq-upload.md
+++ b/docs/api/fastq-upload.md
@@ -30,8 +30,9 @@ Optional: `library_id`, `platform`, `notes` (non-empty strings are stored in the
 
 ### Errors
 
-- **400** `application/problem+json` — malformed JSON, unknown fields, or validation failures (`errors[]` sorted by `field`).
-- **503** — database not configured for the API process.
+- **400** `application/problem+json` — malformed JSON, unknown fields, or validation failures (`errors[]` sorted by `field`, then `message`).
+- **500** `application/problem+json` — persistence failure when saving the job row.
+- **503** `application/problem+json` — database not configured for the API process.
 
 ## Example
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,6 +50,10 @@ go run ./cmd/migrate up
 
 Use the same environment variables as in `.env` (`POSTGRES_*` or `POSTGRES_DSN`) so the migrate command targets your Compose Postgres instance.
 
+## FASTQ upload metadata API
+
+After migrations and with Postgres reachable, the API can register FASTQ ingestion jobs. See [docs/api/fastq-upload.md](./api/fastq-upload.md).
+
 ## Verification commands
 
 - API:


### PR DESCRIPTION
## Summary
Implements [Issue #6](https://github.com/AminN77/senju/issues/6): `POST /v1/jobs/fastq-upload/metadata` to validate paired-end FASTQ ingestion metadata, return deterministic `application/problem+json` errors, and persist a `jobs` row via `job.Repository` when PostgreSQL is configured.

## Changes
- **API**: Problem details helper, FASTQ handler (unknown-field rejection, URI validation, canonical `input_ref` JSON)
- **Wiring**: `pgxpool` + Postgres job repository in `cmd/api` when `POSTGRES_DSN` set; **503** if DB not configured
- **OpenAPI**: New path and schemas; spec test path list updated
- **Docs**: `docs/api/fastq-upload.md`, link from setup
- **Tests**: Handler tests (201/400/503, S3 URIs, optional fields)

## Test evidence
- `go test -race -p 1 ./...`
- `golangci-lint run ./...`

## Rollback
- Revert PR; no migration changes in this PR (depends on existing `jobs` schema from Issue 5).

Closes #6

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FASTQ upload metadata API (POST /v1/jobs/fastq-upload/metadata) to register paired-end FASTQ data; returns job_id (201) on success.
  * Endpoint returns 503 when persistence is not configured.

* **Bug Fixes / Validation**
  * Robust JSON parsing and deterministic, field-sorted validation errors; detailed error payloads for malformed or unknown JSON.

* **Documentation**
  * API docs and OpenAPI spec updated with request/response schemas and examples.

* **Tests**
  * New tests covering success, validation, error mapping, and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->