### PR TITLE
feat(ingestion): streaming FASTQ format validator (#8)

### DIFF
--- a/backend/internal/api/fastqupload/handler.go
+++ b/backend/internal/api/fastqupload/handler.go
@@ -9,14 +9,23 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/fastq"
 	"github.com/AminN77/senju/backend/internal/job"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 // StageFastqUploadQueued is the initial pipeline stage for a FASTQ metadata job row.
 const StageFastqUploadQueued = "fastq_upload_queued"
+
+// StageFastqValidated indicates FASTQ stream format passed validation.
+const StageFastqValidated = "fastq_validated"
+
+// StageFastqValidationFailed indicates FASTQ stream format failed validation.
+const StageFastqValidationFailed = "fastq_validation_failed"
 
 // Request is the JSON body for POST .../fastq-upload/metadata (paired-end MVP).
 type Request struct {
@@ -33,14 +42,24 @@ type CreateResponse struct {
 	JobID string `json:"job_id"`
 }
 
+// ValidateResponse is returned by FASTQ streaming format validation.
+type ValidateResponse struct {
+	Valid         bool   `json:"valid"`
+	Records       int64  `json:"records"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	FailureRecord int64  `json:"failure_record,omitempty"`
+}
+
 // Register mounts POST /fastq-upload/metadata on the given /v1/jobs group.
 // If repo is nil, the handler returns 503 (database not configured).
 func Register(g *gin.RouterGroup, repo job.Repository) {
 	if repo == nil {
 		g.POST("/fastq-upload/metadata", handleNoDatabase)
+		g.POST("/fastq-upload/:job_id/validate", handleNoDatabase)
 		return
 	}
 	g.POST("/fastq-upload/metadata", handleCreate(repo))
+	g.POST("/fastq-upload/:job_id/validate", handleValidate(repo))
 }
 
 func handleNoDatabase(c *gin.Context) {
@@ -186,4 +205,78 @@ func canonicalInputJSON(req Request) (json.RawMessage, error) {
 		canon["notes"] = strings.TrimSpace(*req.Notes)
 	}
 	return json.Marshal(canon)
+}
+
+func handleValidate(repo job.Repository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		jobIDRaw := strings.TrimSpace(c.Param("job_id"))
+		jobID, err := uuid.Parse(jobIDRaw)
+		if err != nil {
+			problem.Validation(c, "one or more fields failed validation", []problem.FieldError{
+				{Field: "job_id", Message: "invalid_uuid"},
+			})
+			return
+		}
+
+		res, err := fastq.ValidateStream(c.Request.Body)
+		if err != nil {
+			problem.Validation(c, "one or more fields failed validation", []problem.FieldError{
+				{Field: "fastq", Message: "could_not_validate_stream"},
+			})
+			return
+		}
+
+		stage := StageFastqValidated
+		status := job.StatusSucceeded
+		if !res.Valid {
+			stage = StageFastqValidationFailed
+			status = job.StatusFailed
+		}
+
+		payload, err := json.Marshal(map[string]any{
+			"kind":           "fastq_validation_v1",
+			"valid":          res.Valid,
+			"records":        res.Records,
+			"failure_reason": res.FailureReason,
+			"failure_record": res.FailureRecord,
+			"validated_at":   time.Now().UTC().Format(time.RFC3339Nano),
+		})
+		if err != nil {
+			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
+				Type:   problem.TypeInternalError,
+				Title:  "Internal error",
+				Status: http.StatusInternalServerError,
+				Detail: "could not build validation payload",
+			})
+			return
+		}
+
+		_, err = repo.Update(c.Request.Context(), jobID, job.UpdateParams{
+			Status:    status,
+			Stage:     stage,
+			OutputRef: payload,
+		})
+		if errors.Is(err, job.ErrNotFound) {
+			problem.Validation(c, "one or more fields failed validation", []problem.FieldError{
+				{Field: "job_id", Message: "not_found"},
+			})
+			return
+		}
+		if err != nil {
+			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
+				Type:   problem.TypeInternalError,
+				Title:  "Internal error",
+				Status: http.StatusInternalServerError,
+				Detail: "could not persist validation result",
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, ValidateResponse{
+			Valid:         res.Valid,
+			Records:       res.Records,
+			FailureReason: res.FailureReason,
+			FailureRecord: res.FailureRecord,
+		})
+	}
 }

--- a/backend/internal/api/fastqupload/handler.go
+++ b/backend/internal/api/fastqupload/handler.go
@@ -233,14 +233,17 @@ func handleValidate(repo job.Repository) gin.HandlerFunc {
 			status = job.StatusFailed
 		}
 
-		payload, err := json.Marshal(map[string]any{
-			"kind":           "fastq_validation_v1",
-			"valid":          res.Valid,
-			"records":        res.Records,
-			"failure_reason": res.FailureReason,
-			"failure_record": res.FailureRecord,
-			"validated_at":   time.Now().UTC().Format(time.RFC3339Nano),
-		})
+		payloadMap := map[string]any{
+			"kind":         "fastq_validation_v1",
+			"valid":        res.Valid,
+			"records":      res.Records,
+			"validated_at": time.Now().UTC().Format(time.RFC3339Nano),
+		}
+		if !res.Valid {
+			payloadMap["failure_reason"] = res.FailureReason
+			payloadMap["failure_record"] = res.FailureRecord
+		}
+		payload, err := json.Marshal(payloadMap)
 		if err != nil {
 			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
 				Type:   problem.TypeInternalError,

--- a/backend/internal/api/fastqupload/handler_test.go
+++ b/backend/internal/api/fastqupload/handler_test.go
@@ -297,6 +297,7 @@ func TestPostFastqValidate_200_Invalid(t *testing.T) {
 
 	body := "@r1\nACGT\n+\nII\n"
 	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/"+created.ID.String()+"/validate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -315,6 +316,12 @@ func TestPostFastqValidate_200_Invalid(t *testing.T) {
 	}
 	if updated.Stage != StageFastqValidationFailed || updated.Status != job.StatusFailed {
 		t.Fatalf("updated job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"failure_reason":"quality_length_mismatch"`)) {
+		t.Fatalf("output_ref missing failure_reason: %s", updated.OutputRef)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"failure_record":1`)) {
+		t.Fatalf("output_ref missing failure_record: %s", updated.OutputRef)
 	}
 }
 

--- a/backend/internal/api/fastqupload/handler_test.go
+++ b/backend/internal/api/fastqupload/handler_test.go
@@ -239,3 +239,95 @@ func TestPostFastqMetadata_OptionalFieldsStored(t *testing.T) {
 		t.Fatalf("input_ref: %s", j.InputRef)
 	}
 }
+
+func TestPostFastqValidate_200_Valid(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	st := stub.New()
+	created, err := st.Create(context.Background(), job.CreateParams{
+		Status: job.StatusPending,
+		Stage:  StageFastqUploadQueued,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), st)
+
+	body := "@r1\nACGT\n+\nIIII\n"
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/"+created.ID.String()+"/validate", strings.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var got ValidateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !got.Valid || got.Records != 1 {
+		t.Fatalf("response %+v", got)
+	}
+	updated, err := st.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Stage != StageFastqValidated || updated.Status != job.StatusSucceeded {
+		t.Fatalf("updated job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"kind":"fastq_validation_v1"`)) {
+		t.Fatalf("output_ref: %s", updated.OutputRef)
+	}
+}
+
+func TestPostFastqValidate_200_Invalid(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	st := stub.New()
+	created, err := st.Create(context.Background(), job.CreateParams{
+		Status: job.StatusPending,
+		Stage:  StageFastqUploadQueued,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), st)
+
+	body := "@r1\nACGT\n+\nII\n"
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/"+created.ID.String()+"/validate", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var got ValidateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Valid || got.FailureReason != "quality_length_mismatch" {
+		t.Fatalf("response %+v", got)
+	}
+	updated, err := st.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Stage != StageFastqValidationFailed || updated.Status != job.StatusFailed {
+		t.Fatalf("updated job %+v", updated)
+	}
+}
+
+func TestPostFastqValidate_400_BadJobID(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1/jobs"), stub.New())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/fastq-upload/not-a-uuid/validate", strings.NewReader("@r\nA\n+\n!\n"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+}

--- a/backend/internal/fastq/validator.go
+++ b/backend/internal/fastq/validator.go
@@ -1,0 +1,99 @@
+// Package fastq validates FASTQ content using a streaming parser.
+package fastq
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+)
+
+const maxLineBytes = 1 << 20 // 1 MiB hard cap to keep memory bounded.
+
+// Result captures validation outcome and details used for job output_ref.
+type Result struct {
+	Valid         bool   `json:"valid"`
+	Records       int64  `json:"records"`
+	FailureReason string `json:"failure_reason,omitempty"`
+	FailureRecord int64  `json:"failure_record,omitempty"`
+}
+
+// ValidateStream validates FASTQ syntax from r without loading the full file in memory.
+func ValidateStream(r io.Reader) (Result, error) {
+	br := bufio.NewReaderSize(r, 64*1024)
+	var rec int64
+	for {
+		h, ok, err := readLineBounded(br, maxLineBytes)
+		if err != nil {
+			return Result{}, err
+		}
+		if !ok {
+			if rec == 0 {
+				return Result{Valid: false, FailureReason: "empty_file"}, nil
+			}
+			return Result{Valid: true, Records: rec}, nil
+		}
+
+		rec++
+		if !strings.HasPrefix(h, "@") {
+			return Result{Valid: false, Records: rec - 1, FailureReason: "header_missing_at", FailureRecord: rec}, nil
+		}
+
+		seq, seqOK, err := readLineBounded(br, maxLineBytes)
+		if err != nil {
+			return Result{}, err
+		}
+		if !seqOK || seq == "" {
+			return Result{Valid: false, Records: rec - 1, FailureReason: "missing_sequence", FailureRecord: rec}, nil
+		}
+
+		plus, plusOK, err := readLineBounded(br, maxLineBytes)
+		if err != nil {
+			return Result{}, err
+		}
+		if !plusOK || !strings.HasPrefix(plus, "+") {
+			return Result{Valid: false, Records: rec - 1, FailureReason: "plus_missing", FailureRecord: rec}, nil
+		}
+
+		qual, qualOK, err := readLineBounded(br, maxLineBytes)
+		if err != nil {
+			return Result{}, err
+		}
+		if !qualOK {
+			return Result{Valid: false, Records: rec - 1, FailureReason: "missing_quality", FailureRecord: rec}, nil
+		}
+		if len(seq) != len(qual) {
+			return Result{Valid: false, Records: rec - 1, FailureReason: "quality_length_mismatch", FailureRecord: rec}, nil
+		}
+	}
+}
+
+func readLineBounded(r *bufio.Reader, limit int) (string, bool, error) {
+	var total int
+	var b strings.Builder
+	for {
+		part, err := r.ReadSlice('\n')
+		total += len(part)
+		if total > limit {
+			return "", false, errors.New("fastq line exceeds maximum allowed length")
+		}
+		if len(part) > 0 {
+			b.Write(part)
+		}
+		switch {
+		case err == nil:
+			line := strings.TrimRight(b.String(), "\r\n")
+			return line, true, nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue
+		case errors.Is(err, io.EOF):
+			if total == 0 {
+				return "", false, nil
+			}
+			line := strings.TrimRight(b.String(), "\r\n")
+			return line, true, nil
+		default:
+			return "", false, err
+		}
+	}
+}

--- a/backend/internal/fastq/validator_test.go
+++ b/backend/internal/fastq/validator_test.go
@@ -1,0 +1,61 @@
+package fastq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateStream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want Result
+	}{
+		{
+			name: "valid single record",
+			in:   "@r1\nACTG\n+\nIIII\n",
+			want: Result{Valid: true, Records: 1},
+		},
+		{
+			name: "valid two records",
+			in:   "@r1\nACTG\n+\nIIII\n@r2\nNN\n+\n!!\n",
+			want: Result{Valid: true, Records: 2},
+		},
+		{
+			name: "empty file",
+			in:   "",
+			want: Result{Valid: false, FailureReason: "empty_file"},
+		},
+		{
+			name: "missing at header",
+			in:   "r1\nACTG\n+\nIIII\n",
+			want: Result{Valid: false, FailureReason: "header_missing_at", FailureRecord: 1},
+		},
+		{
+			name: "quality mismatch",
+			in:   "@r1\nACTG\n+\nIII\n",
+			want: Result{Valid: false, FailureReason: "quality_length_mismatch", FailureRecord: 1},
+		},
+		{
+			name: "missing quality line",
+			in:   "@r1\nACTG\n+\n",
+			want: Result{Valid: false, FailureReason: "missing_quality", FailureRecord: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateStream(strings.NewReader(tt.in))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got=%+v want=%+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/fastq/validator_test.go
+++ b/backend/internal/fastq/validator_test.go
@@ -43,6 +43,16 @@ func TestValidateStream(t *testing.T) {
 			in:   "@r1\nACTG\n+\n",
 			want: Result{Valid: false, FailureReason: "missing_quality", FailureRecord: 1},
 		},
+		{
+			name: "missing sequence line",
+			in:   "@r1\n",
+			want: Result{Valid: false, FailureReason: "missing_sequence", FailureRecord: 1},
+		},
+		{
+			name: "missing plus line",
+			in:   "@r1\nACTG\n",
+			want: Result{Valid: false, FailureReason: "plus_missing", FailureRecord: 1},
+		},
 	}
 
 	for _, tt := range tests {
@@ -57,5 +67,19 @@ func TestValidateStream(t *testing.T) {
 				t.Fatalf("got=%+v want=%+v", got, tt.want)
 			}
 		})
+	}
+}
+
+func BenchmarkValidateStream(b *testing.B) {
+	sample := "@r1\nACTGACTG\n+\nIIIIIIII\n@r2\nNNNN\n+\n####\n"
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		res, err := ValidateStream(strings.NewReader(sample))
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+		if !res.Valid || res.Records != 2 {
+			b.Fatalf("unexpected result: %+v", res)
+		}
 	}
 }

--- a/backend/internal/job/db/jobdb/job.sql.go
+++ b/backend/internal/job/db/jobdb/job.sql.go
@@ -89,7 +89,8 @@ UPDATE public.jobs
 SET status = $2,
     stage = $3,
     started_at = COALESCE($4, started_at),
-    completed_at = COALESCE($5, completed_at)
+    completed_at = COALESCE($5, completed_at),
+    output_ref = COALESCE($6, output_ref)
 WHERE id = $1
 RETURNING id, status, stage, input_ref, output_ref, created_at, updated_at, started_at, completed_at
 `
@@ -100,6 +101,7 @@ type UpdateJobParams struct {
 	Stage       string             `json:"stage"`
 	StartedAt   pgtype.Timestamptz `json:"started_at"`
 	CompletedAt pgtype.Timestamptz `json:"completed_at"`
+	OutputRef   []byte             `json:"output_ref"`
 }
 
 func (q *Queries) UpdateJob(ctx context.Context, arg UpdateJobParams) (Job, error) {
@@ -109,6 +111,7 @@ func (q *Queries) UpdateJob(ctx context.Context, arg UpdateJobParams) (Job, erro
 		arg.Stage,
 		arg.StartedAt,
 		arg.CompletedAt,
+		arg.OutputRef,
 	)
 	var i Job
 	err := row.Scan(

--- a/backend/internal/job/db/queries/job.sql
+++ b/backend/internal/job/db/queries/job.sql
@@ -22,6 +22,7 @@ UPDATE public.jobs
 SET status = $2,
     stage = $3,
     started_at = COALESCE($4, started_at),
-    completed_at = COALESCE($5, completed_at)
+    completed_at = COALESCE($5, completed_at),
+    output_ref = COALESCE($6, output_ref)
 WHERE id = $1
 RETURNING id, status, stage, input_ref, output_ref, created_at, updated_at, started_at, completed_at;

--- a/backend/internal/job/job.go
+++ b/backend/internal/job/job.go
@@ -55,6 +55,7 @@ type CreateParams struct {
 type UpdateParams struct {
 	Status      Status
 	Stage       string
+	OutputRef   json.RawMessage
 	StartedAt   *time.Time
 	CompletedAt *time.Time
 }

--- a/backend/internal/job/job.go
+++ b/backend/internal/job/job.go
@@ -51,7 +51,10 @@ type CreateParams struct {
 	CompletedAt *time.Time
 }
 
-// UpdateParams holds mutable job fields for updates. Nil time pointers mean "leave existing value".
+// UpdateParams holds mutable job fields for updates.
+// StartedAt/CompletedAt nil pointers mean "leave existing value".
+// OutputRef uses the same semantics as storage mapping: len(OutputRef) == 0 means
+// "leave existing value unchanged"; to persist explicit JSON null, pass []byte("null").
 type UpdateParams struct {
 	Status      Status
 	Stage       string

--- a/backend/internal/job/postgres/convert.go
+++ b/backend/internal/job/postgres/convert.go
@@ -67,13 +67,17 @@ func timeToTimestamptz(t *time.Time) pgtype.Timestamptz {
 }
 
 func mapUpdateParams(id uuid.UUID, p job.UpdateParams) jobdb.UpdateJobParams {
-	return jobdb.UpdateJobParams{
+	arg := jobdb.UpdateJobParams{
 		ID:          uuidToPgUUID(id),
 		Status:      string(p.Status),
 		Stage:       p.Stage,
 		StartedAt:   timeToTimestamptz(p.StartedAt),
 		CompletedAt: timeToTimestamptz(p.CompletedAt),
 	}
+	if len(p.OutputRef) > 0 {
+		arg.OutputRef = append([]byte(nil), p.OutputRef...)
+	}
+	return arg
 }
 
 func mapCreateParams(id uuid.UUID, p job.CreateParams) jobdb.CreateJobParams {

--- a/backend/internal/job/postgres/repository_integration_test.go
+++ b/backend/internal/job/postgres/repository_integration_test.go
@@ -73,8 +73,9 @@ func TestRepository_CRUD(t *testing.T) {
 	}
 
 	updated, err := repo.Update(ctx, created.ID, job.UpdateParams{
-		Status: job.StatusRunning,
-		Stage:  "align",
+		Status:    job.StatusRunning,
+		Stage:     "align",
+		OutputRef: json.RawMessage(`{"kind":"fastq_validation_v1","valid":true}`),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -84,6 +85,16 @@ func TestRepository_CRUD(t *testing.T) {
 	}
 	if !updated.UpdatedAt.After(created.UpdatedAt) {
 		t.Fatalf("expected updated_at to advance: before=%v after=%v", created.UpdatedAt, updated.UpdatedAt)
+	}
+	var outObj, outWant any
+	if err := json.Unmarshal(updated.OutputRef, &outObj); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal([]byte(`{"kind":"fastq_validation_v1","valid":true}`), &outWant); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(outObj, outWant) {
+		t.Fatalf("output ref: %s", updated.OutputRef)
 	}
 }
 

--- a/backend/internal/job/stub/stub.go
+++ b/backend/internal/job/stub/stub.go
@@ -100,6 +100,9 @@ func (r *Repository) Update(ctx context.Context, id uuid.UUID, p job.UpdateParam
 	}
 	j.Status = p.Status
 	j.Stage = p.Stage
+	if p.OutputRef != nil {
+		j.OutputRef = cloneRawMessage(p.OutputRef)
+	}
 	if p.StartedAt != nil {
 		j.StartedAt = cloneTimePtr(p.StartedAt)
 	}

--- a/backend/internal/job/stub/stub.go
+++ b/backend/internal/job/stub/stub.go
@@ -100,7 +100,7 @@ func (r *Repository) Update(ctx context.Context, id uuid.UUID, p job.UpdateParam
 	}
 	j.Status = p.Status
 	j.Stage = p.Stage
-	if p.OutputRef != nil {
+	if len(p.OutputRef) > 0 {
 		j.OutputRef = cloneRawMessage(p.OutputRef)
 	}
 	if p.StartedAt != nil {

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -140,6 +140,54 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetails"
+  /v1/jobs/fastq-upload/{job_id}/validate:
+    post:
+      tags:
+        - Ingestion
+      summary: Validate FASTQ stream and persist result
+      description: |
+        Streams FASTQ content from the request body, validates format incrementally with bounded memory,
+        and stores the validation output on the referenced job (`output_ref`).
+      operationId: postFastqUploadValidate
+      parameters:
+        - name: job_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              description: Raw FASTQ content
+      responses:
+        "200":
+          description: Validation completed (valid or invalid FASTQ)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FastqValidationResponse"
+        "400":
+          description: Invalid job_id or unreadable validation stream
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "500":
+          description: Persistence failure when storing validation result
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "503":
+          description: Database not configured
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
   /v1/objects/multipart:
     post:
       tags:
@@ -323,6 +371,26 @@ components:
         job_id:
           type: string
           format: uuid
+    FastqValidationResponse:
+      type: object
+      required:
+        - valid
+        - records
+      properties:
+        valid:
+          type: boolean
+          description: True when FASTQ format checks pass.
+        records:
+          type: integer
+          format: int64
+          description: Number of complete FASTQ records read.
+        failure_reason:
+          type: string
+          description: Present only when valid=false.
+        failure_record:
+          type: integer
+          format: int64
+          description: One-based record index for the failure, when available.
     MultipartInitRequest:
       type: object
       additionalProperties: false

--- a/docs/api/fastq-upload.md
+++ b/docs/api/fastq-upload.md
@@ -48,3 +48,26 @@ curl -sS -X POST "http://localhost:${API_PORT:-8080}/v1/jobs/fastq-upload/metada
 ```
 
 OpenAPI: [backend/openapi/openapi.yaml](../../backend/openapi/openapi.yaml).
+
+## Streaming FASTQ validator
+
+- **POST** `/v1/jobs/fastq-upload/{job_id}/validate`
+- **Content-Type:** `text/plain`
+
+This endpoint streams FASTQ content directly from the request body (bounded memory parser) and stores the validation result in the target job's `output_ref` JSON.
+
+### Success (200)
+
+```json
+{ "valid": true, "records": 12345 }
+```
+
+Invalid FASTQ still returns `200` with `valid: false`, plus `failure_reason` and `failure_record`; the job is marked failed with stage `fastq_validation_failed`.
+
+### Example
+
+```bash
+curl -sS -X POST "http://localhost:${API_PORT:-8080}/v1/jobs/fastq-upload/${JOB_ID}/validate" \
+  -H "Content-Type: text/plain" \
+  --data-binary $'@read1\nACGT\n+\nIIII\n'
+```


### PR DESCRIPTION
## Summary
- Closes #8.
- Add a bounded-memory streaming FASTQ validator and expose `POST /v1/jobs/fastq-upload/{job_id}/validate`.
- Persist validation outcomes (`valid`, `records`, failure metadata) in job `output_ref`, with stage/status transitions and updated API docs/OpenAPI.

## Test evidence
- Ran `cd backend && go test ./...` (pass).
- Ran `cd backend && golangci-lint run ./...` (pass).
- Added validator fixture coverage for valid/invalid FASTQ and explicit failure reasons.
- Added handler tests covering valid stream, invalid stream, and invalid `job_id` behavior with persisted job updates.

## Failure cases validated
- Empty FASTQ (`empty_file`).
- Header missing `@` (`header_missing_at`).
- Missing sequence/plus/quality lines.
- Sequence and quality length mismatch (`quality_length_mismatch`).

## Rollback notes
- Revert this PR to remove the new validator endpoint and job `output_ref` update path.
- No schema migration is introduced; rollback is code-only and low-risk.
- Existing `/v1/jobs/fastq-upload/metadata` behavior remains unchanged.

## Test plan
- [x] `cd backend && go test ./...`
- [x] `cd backend && golangci-lint run ./...`
- [ ] (Optional smoke) Create job via metadata endpoint, validate valid FASTQ, confirm job stage/status/output_ref.
- [ ] (Optional smoke) Validate malformed FASTQ and confirm failure reason is persisted.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /v1/jobs/fastq-upload/{job_id}/validate: a streaming FASTQ validator that returns JSON with validity, record count, and failure details and persists results to the job record (updating job status/stage).

* **Bug Fixes**
  * Returns appropriate HTTP responses for invalid job IDs, unreadable streams, persistence failures, and service-unavailable when DB is missing.

* **Documentation**
  * OpenAPI and API docs updated for the new endpoint.

* **Tests**
  * Added unit/integration tests and a benchmark for the validator and handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->