### PR TITLE
feat(pipeline): FastQC execution worker stage (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@
 ## Pipeline queue
 
 - NATS/JetStream queue package with retry + dead-letter semantics: `docs/pipeline/nats-queue.md`
+- FastQC worker stage implementation: `backend/internal/pipeline/fastqc`

--- a/backend/internal/pipeline/fastqc/worker.go
+++ b/backend/internal/pipeline/fastqc/worker.go
@@ -1,0 +1,184 @@
+// Package fastqc implements the FastQC pipeline stage worker.
+package fastqc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/AminN77/senju/backend/internal/job"
+	"github.com/AminN77/senju/backend/internal/queue"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// StageFastQCRunning marks active FastQC stage execution.
+	StageFastQCRunning = "fastqc_running"
+	// StageFastQCSucceeded marks successful FastQC stage completion.
+	StageFastQCSucceeded = "fastqc_succeeded"
+	// StageFastQCFailed marks terminal FastQC stage failure.
+	StageFastQCFailed = "fastqc_failed"
+)
+
+// CommandRunner executes the FastQC command and returns process exit code.
+type CommandRunner interface {
+	Run(ctx context.Context, args ...string) (int, error)
+}
+
+// ExecRunner executes commands with os/exec.
+type ExecRunner struct {
+}
+
+// Run executes one process and returns either zero or the process exit code.
+func (r ExecRunner) Run(ctx context.Context, args ...string) (int, error) {
+	// #nosec G204 -- command binary is fixed to "fastqc"; args are validated stage inputs.
+	cmd := exec.CommandContext(ctx, "fastqc", args...)
+	err := cmd.Run()
+	if err == nil {
+		return 0, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode(), err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return -1, err
+	}
+	return -1, err
+}
+
+// Config controls FastQC worker behavior.
+type Config struct {
+	DefaultTimeout time.Duration
+}
+
+// Worker executes FastQC for queue messages and persists job stage state.
+type Worker struct {
+	repo   job.Repository
+	runner CommandRunner
+	log    zerolog.Logger
+	cfg    Config
+}
+
+// NewWorker creates a FastQC stage worker.
+func NewWorker(repo job.Repository, runner CommandRunner, log zerolog.Logger, cfg Config) (*Worker, error) {
+	if repo == nil {
+		return nil, errors.New("fastqc worker: repo is nil")
+	}
+	if runner == nil {
+		return nil, errors.New("fastqc worker: runner is nil")
+	}
+	if cfg.DefaultTimeout <= 0 {
+		cfg.DefaultTimeout = 15 * time.Minute
+	}
+	return &Worker{repo: repo, runner: runner, log: log, cfg: cfg}, nil
+}
+
+type payload struct {
+	InputPath      string `json:"input_path"`
+	OutputDir      string `json:"output_dir"`
+	ReportHTMLURI  string `json:"report_html_uri,omitempty"`
+	ReportZIPURI   string `json:"report_zip_uri,omitempty"`
+	TimeoutSeconds int64  `json:"timeout_seconds,omitempty"`
+}
+
+// Handle is compatible with queue handlers and executes one FastQC job.
+func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
+	jobID, err := uuid.Parse(msg.JobID)
+	if err != nil {
+		return fmt.Errorf("fastqc worker: invalid job id: %w", err)
+	}
+
+	p, err := decodePayload(msg.Payload)
+	if err != nil {
+		return err
+	}
+
+	started := time.Now().UTC()
+	if _, err := w.repo.Update(ctx, jobID, job.UpdateParams{
+		Status:    job.StatusRunning,
+		Stage:     StageFastQCRunning,
+		StartedAt: &started,
+	}); err != nil {
+		return fmt.Errorf("fastqc worker: mark running: %w", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, resolveTimeout(w.cfg.DefaultTimeout, p.TimeoutSeconds))
+	defer cancel()
+
+	stageStart := time.Now()
+	exitCode, runErr := w.runner.Run(runCtx, "--outdir", p.OutputDir, p.InputPath)
+	duration := time.Since(stageStart)
+	completed := time.Now().UTC()
+
+	status := job.StatusSucceeded
+	stage := StageFastQCSucceeded
+	if runErr != nil {
+		status = job.StatusFailed
+		stage = StageFastQCFailed
+	}
+
+	outRef, marshalErr := buildOutputRef(exitCode, duration, p, runErr)
+	if marshalErr != nil {
+		return fmt.Errorf("fastqc worker: output_ref: %w", marshalErr)
+	}
+
+	if _, err := w.repo.Update(runCtx, jobID, job.UpdateParams{
+		Status:      status,
+		Stage:       stage,
+		CompletedAt: &completed,
+		OutputRef:   outRef,
+	}); err != nil {
+		return fmt.Errorf("fastqc worker: mark completion: %w", err)
+	}
+
+	w.log.Info().
+		Str("job_id", msg.JobID).
+		Str("stage", "fastqc").
+		Int("exit_code", exitCode).
+		Dur("duration", duration).
+		Msg("pipeline stage completed")
+
+	return runErr
+}
+
+func decodePayload(raw json.RawMessage) (payload, error) {
+	var p payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return p, fmt.Errorf("fastqc worker: decode payload: %w", err)
+	}
+	if p.InputPath == "" {
+		return p, errors.New("fastqc worker: payload input_path is required")
+	}
+	if p.OutputDir == "" {
+		return p, errors.New("fastqc worker: payload output_dir is required")
+	}
+	return p, nil
+}
+
+func resolveTimeout(defaultTimeout time.Duration, timeoutSeconds int64) time.Duration {
+	if timeoutSeconds <= 0 {
+		return defaultTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
+}
+
+func buildOutputRef(exitCode int, duration time.Duration, p payload, runErr error) (json.RawMessage, error) {
+	m := map[string]any{
+		"kind":        "fastqc_report_v1",
+		"exit_code":   exitCode,
+		"duration_ms": duration.Milliseconds(),
+		"artifacts": map[string]any{
+			"html_uri": p.ReportHTMLURI,
+			"zip_uri":  p.ReportZIPURI,
+		},
+	}
+	if runErr != nil {
+		m["error"] = runErr.Error()
+	}
+	return json.Marshal(m)
+}

--- a/backend/internal/pipeline/fastqc/worker.go
+++ b/backend/internal/pipeline/fastqc/worker.go
@@ -127,7 +127,7 @@ func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
 		return fmt.Errorf("fastqc worker: output_ref: %w", marshalErr)
 	}
 
-	if _, err := w.repo.Update(runCtx, jobID, job.UpdateParams{
+	if _, err := w.repo.Update(ctx, jobID, job.UpdateParams{
 		Status:      status,
 		Stage:       stage,
 		CompletedAt: &completed,

--- a/backend/internal/pipeline/fastqc/worker_test.go
+++ b/backend/internal/pipeline/fastqc/worker_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,9 +25,37 @@ func (f fakeRunner) Run(ctx context.Context, args ...string) (int, error) {
 	return f.run(ctx, args...)
 }
 
+type recordingRepo struct {
+	base *stub.Repository
+
+	mu             sync.Mutex
+	updateStatuses []job.Status
+	updateCtxErrs  []error
+}
+
+func newRecordingRepo() *recordingRepo {
+	return &recordingRepo{base: stub.New()}
+}
+
+func (r *recordingRepo) Create(ctx context.Context, p job.CreateParams) (*job.Job, error) {
+	return r.base.Create(ctx, p)
+}
+
+func (r *recordingRepo) GetByID(ctx context.Context, id uuid.UUID) (*job.Job, error) {
+	return r.base.GetByID(ctx, id)
+}
+
+func (r *recordingRepo) Update(ctx context.Context, id uuid.UUID, p job.UpdateParams) (*job.Job, error) {
+	r.mu.Lock()
+	r.updateStatuses = append(r.updateStatuses, p.Status)
+	r.updateCtxErrs = append(r.updateCtxErrs, ctx.Err())
+	r.mu.Unlock()
+	return r.base.Update(ctx, id, p)
+}
+
 func TestWorkerHandle_SuccessStoresArtifactsAndLogs(t *testing.T) {
 	t.Parallel()
-	repo := stub.New()
+	repo := newRecordingRepo()
 	created, err := repo.Create(context.Background(), job.CreateParams{
 		Status: job.StatusPending,
 		Stage:  "queued",
@@ -81,7 +110,7 @@ func TestWorkerHandle_SuccessStoresArtifactsAndLogs(t *testing.T) {
 
 func TestWorkerHandle_TimeoutAndCancellationEnforced(t *testing.T) {
 	t.Parallel()
-	repo := stub.New()
+	repo := newRecordingRepo()
 	created, err := repo.Create(context.Background(), job.CreateParams{
 		Status: job.StatusPending,
 		Stage:  "queued",
@@ -107,6 +136,18 @@ func TestWorkerHandle_TimeoutAndCancellationEnforced(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected deadline exceeded, got %v", err)
 	}
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.updateStatuses) != 2 {
+		t.Fatalf("expected 2 updates, got %d", len(repo.updateStatuses))
+	}
+	if repo.updateStatuses[1] != job.StatusFailed {
+		t.Fatalf("second update status = %s", repo.updateStatuses[1])
+	}
+	if repo.updateCtxErrs[1] != nil {
+		t.Fatalf("completion update used expired context: %v", repo.updateCtxErrs[1])
+	}
+
 	updated, err := repo.GetByID(context.Background(), created.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +162,7 @@ func TestWorkerHandle_TimeoutAndCancellationEnforced(t *testing.T) {
 
 func TestWorkerHandle_InvalidPayload(t *testing.T) {
 	t.Parallel()
-	repo := stub.New()
+	repo := newRecordingRepo()
 	worker, err := NewWorker(repo, fakeRunner{
 		run: func(_ context.Context, _ ...string) (int, error) { return 0, nil },
 	}, zerolog.Nop(), Config{})

--- a/backend/internal/pipeline/fastqc/worker_test.go
+++ b/backend/internal/pipeline/fastqc/worker_test.go
@@ -1,0 +1,138 @@
+package fastqc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AminN77/senju/backend/internal/job"
+	"github.com/AminN77/senju/backend/internal/job/stub"
+	"github.com/AminN77/senju/backend/internal/queue"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type fakeRunner struct {
+	run func(ctx context.Context, args ...string) (int, error)
+}
+
+func (f fakeRunner) Run(ctx context.Context, args ...string) (int, error) {
+	return f.run(ctx, args...)
+}
+
+func TestWorkerHandle_SuccessStoresArtifactsAndLogs(t *testing.T) {
+	t.Parallel()
+	repo := stub.New()
+	created, err := repo.Create(context.Background(), job.CreateParams{
+		Status: job.StatusPending,
+		Stage:  "queued",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := zerolog.New(&logBuf)
+	w, err := NewWorker(repo, fakeRunner{
+		run: func(_ context.Context, args ...string) (int, error) {
+			if strings.Join(args, " ") != "--outdir /tmp/reports /tmp/r1.fastq.gz" {
+				t.Fatalf("args %v", args)
+			}
+			return 0, nil
+		},
+	}, logger, Config{DefaultTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := `{"input_path":"/tmp/r1.fastq.gz","output_dir":"/tmp/reports","report_html_uri":"s3://bucket/r1_fastqc.html","report_zip_uri":"s3://bucket/r1_fastqc.zip"}`
+	err = w.Handle(context.Background(), queue.Message{
+		JobID:   created.ID.String(),
+		Payload: json.RawMessage(payload),
+	})
+	if err != nil {
+		t.Fatalf("handle err: %v", err)
+	}
+
+	updated, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != job.StatusSucceeded || updated.Stage != StageFastQCSucceeded {
+		t.Fatalf("job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"html_uri":"s3://bucket/r1_fastqc.html"`)) {
+		t.Fatalf("output_ref %s", updated.OutputRef)
+	}
+	if !strings.Contains(logBuf.String(), `"job_id":"`+created.ID.String()+`"`) {
+		t.Fatalf("log %s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), `"stage":"fastqc"`) {
+		t.Fatalf("log %s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), `"exit_code":0`) {
+		t.Fatalf("log %s", logBuf.String())
+	}
+}
+
+func TestWorkerHandle_TimeoutAndCancellationEnforced(t *testing.T) {
+	t.Parallel()
+	repo := stub.New()
+	created, err := repo.Create(context.Background(), job.CreateParams{
+		Status: job.StatusPending,
+		Stage:  "queued",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w, err := NewWorker(repo, fakeRunner{
+		run: func(ctx context.Context, _ ...string) (int, error) {
+			<-ctx.Done()
+			return -1, ctx.Err()
+		},
+	}, zerolog.Nop(), Config{DefaultTimeout: 20 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := `{"input_path":"/tmp/r1.fastq.gz","output_dir":"/tmp/reports","timeout_seconds":0}`
+	err = w.Handle(context.Background(), queue.Message{
+		JobID:   created.ID.String(),
+		Payload: json.RawMessage(payload),
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", err)
+	}
+	updated, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != job.StatusFailed || updated.Stage != StageFastQCFailed {
+		t.Fatalf("job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"exit_code":-1`)) {
+		t.Fatalf("output_ref %s", updated.OutputRef)
+	}
+}
+
+func TestWorkerHandle_InvalidPayload(t *testing.T) {
+	t.Parallel()
+	repo := stub.New()
+	worker, err := NewWorker(repo, fakeRunner{
+		run: func(_ context.Context, _ ...string) (int, error) { return 0, nil },
+	}, zerolog.Nop(), Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = worker.Handle(context.Background(), queue.Message{
+		JobID:   uuid.NewString(),
+		Payload: json.RawMessage(`{"output_dir":"/tmp/reports"}`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "input_path is required") {
+		t.Fatalf("unexpected err %v", err)
+	}
+}

--- a/docs/pipeline/nats-queue.md
+++ b/docs/pipeline/nats-queue.md
@@ -42,3 +42,12 @@ Exponential backoff uses:
 - Message is delivered exactly `max_retries + 1` times.
 - Message is dead-lettered after cap is reached.
 - Test asserts no silent loss by observing a dead-letter event and attempt count.
+
+## FastQC stage worker (Issue #10)
+
+FastQC stage execution worker is implemented in `backend/internal/pipeline/fastqc`.
+
+- Queue message includes `job_id` and payload (`input_path`, `output_dir`, optional report artifact URIs).
+- Worker enforces per-job timeout via `context.WithTimeout` (`timeout_seconds` in payload or default config timeout).
+- Worker updates job state to running/succeeded/failed and persists report artifact metadata in `output_ref`.
+- Stage completion log emits `job_id`, `stage`, `exit_code`, and `duration`.


### PR DESCRIPTION
## Summary
- Closes #10.
- Add a queue-compatible FastQC worker (`backend/internal/pipeline/fastqc`) that executes FastQC for one job payload and persists report artifact metadata into `jobs.output_ref`.
- Enforce per-job timeout and cancellation via `context.WithTimeout` (payload `timeout_seconds` with sane default), and persist running/succeeded/failed stage transitions.
- Emit structured stage completion logs with `job_id`, `stage`, `exit_code`, and `duration`.

## Test evidence
- Ran `cd backend && golangci-lint run ./...` (pass).
- Ran `cd backend && go test ./...` (pass).
- Added unit tests in `backend/internal/pipeline/fastqc/worker_test.go` covering:
  - successful execution + artifact metadata persistence + required log fields
  - timeout/cancellation enforcement with failed terminal state and exit code persistence
  - invalid payload validation path

## Failure cases validated
- Invalid queue payload (missing `input_path`) is rejected with explicit worker error.
- Command timeout/cancellation marks job as failed (`fastqc_failed`) and persists failure details.
- Non-zero/failed command execution returns worker error and records exit code + duration metadata.

## Rollback notes
- Revert this PR to remove FastQC worker package and related docs references.
- No schema or migration changes are included; rollback is code-only.
- Existing API and queue transport behavior remain unchanged.

## Test plan
- [x] `cd backend && golangci-lint run ./...`
- [x] `cd backend && go test ./...`
- [x] Validate worker timeout/cancellation and logging fields via unit tests
- [ ] Optional smoke: wire worker to queue consumer process and run against local NATS/fixture paths

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced FastQC pipeline stage for quality control analysis with configurable timeout handling and artifact URI tracking.
  * Supports structured job lifecycle management with running, succeeded, and failed status transitions.

* **Documentation**
  * Added comprehensive documentation covering the FastQC stage message contract, execution behavior, and logging specifications.
  * Updated README with reference to the new FastQC pipeline component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->