### PR TITLE
feat(pipeline): GATK variant-calling worker stage (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@
 - NATS/JetStream queue package with retry + dead-letter semantics: `docs/pipeline/nats-queue.md`
 - FastQC worker stage implementation: `backend/internal/pipeline/fastqc`
 - BWA + SAMtools alignment worker stage implementation: `backend/internal/pipeline/alignment`
+- GATK variant-calling worker stage implementation: `backend/internal/pipeline/gatk`

--- a/backend/internal/pipeline/gatk/worker.go
+++ b/backend/internal/pipeline/gatk/worker.go
@@ -145,8 +145,11 @@ func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
 	}
 	p, err := decodePayload(msg.Payload)
 	if err != nil {
-		_ = w.persistFailure(ctx, jobID, -1, payload{}, 0, 0, err)
-		return err
+		if perr := w.persistFailure(ctx, jobID, -1, payload{}, 0, 0, 0, ErrorClassConfiguration, err); perr != nil {
+			return fmt.Errorf("gatk worker: persist configuration failure: %w", perr)
+		}
+		w.observe("failure", ErrorClassConfiguration, 0)
+		return nil
 	}
 
 	started := time.Now().UTC()
@@ -168,15 +171,16 @@ func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
 	duration := time.Since(stageStart)
 
 	if runErr != nil {
-		if err := w.persistFailure(ctx, jobID, exitCode, p, threads, memMB, runErr); err != nil {
+		class := classifyError(runErr, exitCode)
+		if err := w.persistFailure(ctx, jobID, exitCode, p, threads, memMB, duration, class, runErr); err != nil {
 			return fmt.Errorf("gatk worker: persist failure: %w", err)
 		}
-		w.observe("failure", classifyError(runErr, exitCode), duration)
+		w.observe("failure", class, duration)
 		w.log.Info().Str("job_id", msg.JobID).Str("stage", "gatk").Int("exit_code", exitCode).Dur("duration", duration).Msg("pipeline stage completed")
 		return nil
 	}
 
-	outRef, err := buildOutputRef(exitCode, duration, p, threads, memMB, "")
+	outRef, err := buildOutputRef(exitCode, duration, p, threads, memMB, "", "")
 	if err != nil {
 		return fmt.Errorf("gatk worker: output_ref: %w", err)
 	}
@@ -206,8 +210,8 @@ func (w *Worker) runPipeline(ctx context.Context, p payload, threads, memMB int)
 	return w.runner.Run(ctx, "gatk", args...)
 }
 
-func (w *Worker) persistFailure(ctx context.Context, jobID uuid.UUID, exitCode int, p payload, threads, memMB int, runErr error) error {
-	outRef, err := buildOutputRef(exitCode, 0, p, threads, memMB, runErr.Error())
+func (w *Worker) persistFailure(ctx context.Context, jobID uuid.UUID, exitCode int, p payload, threads, memMB int, duration time.Duration, errorClass string, runErr error) error {
+	outRef, err := buildOutputRef(exitCode, duration, p, threads, memMB, errorClass, runErr.Error())
 	if err != nil {
 		return err
 	}
@@ -276,7 +280,7 @@ func classifyError(err error, exitCode int) string {
 	}
 }
 
-func buildOutputRef(exitCode int, duration time.Duration, p payload, threads, memMB int, errorMsg string) (json.RawMessage, error) {
+func buildOutputRef(exitCode int, duration time.Duration, p payload, threads, memMB int, errorClass, errorMsg string) (json.RawMessage, error) {
 	m := map[string]any{
 		"kind":        "gatk_vcf_v1",
 		"exit_code":   exitCode,
@@ -289,6 +293,9 @@ func buildOutputRef(exitCode int, duration time.Duration, p payload, threads, me
 			"vcf_path": p.OutputVCFPath,
 			"vcf_uri":  p.OutputVCFURI,
 		},
+	}
+	if errorClass != "" {
+		m["error_class"] = errorClass
 	}
 	if errorMsg != "" {
 		m["error"] = errorMsg

--- a/backend/internal/pipeline/gatk/worker.go
+++ b/backend/internal/pipeline/gatk/worker.go
@@ -1,0 +1,297 @@
+// Package gatk implements the GATK variant-calling pipeline worker.
+package gatk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/AminN77/senju/backend/internal/job"
+	"github.com/AminN77/senju/backend/internal/queue"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// StageGATKRunning marks active GATK execution.
+	StageGATKRunning = "gatk_running"
+	// StageGATKSucceeded marks successful GATK completion.
+	StageGATKSucceeded = "gatk_succeeded"
+	// StageGATKFailed marks terminal GATK stage failure.
+	StageGATKFailed = "gatk_failed"
+
+	// ErrorClassTool indicates tool/runtime command failure.
+	ErrorClassTool = "tool"
+	// ErrorClassInfrastructure indicates timeout/infra/runtime environment failure.
+	ErrorClassInfrastructure = "infrastructure"
+	// ErrorClassConfiguration indicates invalid payload or bad stage configuration.
+	ErrorClassConfiguration = "configuration"
+)
+
+// CommandRunner executes GATK command invocations and returns process exit code.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) (int, error)
+}
+
+// ExecRunner executes command binaries through os/exec.
+type ExecRunner struct{}
+
+// Run executes one command and returns either zero or process exit code.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) (int, error) {
+	// #nosec G204 -- command binary/args are controlled by validated stage payload/config.
+	cmd := exec.CommandContext(ctx, name, args...)
+	err := cmd.Run()
+	if err == nil {
+		return 0, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode(), err
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return -1, err
+	}
+	return -1, err
+}
+
+// Metrics exports GATK stage metrics to Prometheus.
+type Metrics struct {
+	duration *prometheus.HistogramVec
+	total    *prometheus.CounterVec
+}
+
+// NewMetrics returns Prometheus collectors for GATK stage observability.
+func NewMetrics() *Metrics {
+	return &Metrics{
+		duration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "senju_pipeline_stage_duration_seconds",
+			Help:    "Duration of pipeline stage executions by stage and outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"stage", "outcome"}),
+		total: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "senju_pipeline_stage_total",
+			Help: "Total pipeline stage executions by stage, outcome, and classified error type.",
+		}, []string{"stage", "outcome", "error_class"}),
+	}
+}
+
+// Collectors returns the metrics collectors for registry registration.
+func (m *Metrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{m.duration, m.total}
+}
+
+// Observe records duration and terminal status classification.
+func (m *Metrics) Observe(stage, outcome, errorClass string, duration time.Duration) {
+	m.duration.WithLabelValues(stage, outcome).Observe(duration.Seconds())
+	m.total.WithLabelValues(stage, outcome, errorClass).Inc()
+}
+
+// Config controls GATK worker defaults.
+type Config struct {
+	DefaultTimeout  time.Duration
+	DefaultThreads  int
+	DefaultMemoryMB int
+}
+
+// Worker executes GATK stage for queue jobs and persists stage transitions.
+type Worker struct {
+	repo    job.Repository
+	runner  CommandRunner
+	log     zerolog.Logger
+	cfg     Config
+	metrics *Metrics
+}
+
+// NewWorker creates a GATK worker with defaults and optional metrics.
+func NewWorker(repo job.Repository, runner CommandRunner, log zerolog.Logger, cfg Config, metrics *Metrics) (*Worker, error) {
+	if repo == nil {
+		return nil, errors.New("gatk worker: repo is nil")
+	}
+	if runner == nil {
+		return nil, errors.New("gatk worker: runner is nil")
+	}
+	if cfg.DefaultTimeout <= 0 {
+		cfg.DefaultTimeout = 90 * time.Minute
+	}
+	if cfg.DefaultThreads <= 0 {
+		cfg.DefaultThreads = 4
+	}
+	if cfg.DefaultMemoryMB <= 0 {
+		cfg.DefaultMemoryMB = 4096
+	}
+	return &Worker{repo: repo, runner: runner, log: log, cfg: cfg, metrics: metrics}, nil
+}
+
+type payload struct {
+	ReferencePath  string `json:"reference_path"`
+	InputBAMPath   string `json:"input_bam_path"`
+	OutputVCFPath  string `json:"output_vcf_path"`
+	OutputVCFURI   string `json:"output_vcf_uri,omitempty"`
+	TimeoutSeconds int64  `json:"timeout_seconds,omitempty"`
+	Threads        int    `json:"threads,omitempty"`
+	MemoryLimitMB  int    `json:"memory_limit_mb,omitempty"`
+}
+
+// Handle executes one GATK stage invocation for the queue message job.
+func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
+	jobID, err := uuid.Parse(msg.JobID)
+	if err != nil {
+		return fmt.Errorf("gatk worker: invalid job id: %w", err)
+	}
+	p, err := decodePayload(msg.Payload)
+	if err != nil {
+		_ = w.persistFailure(ctx, jobID, -1, payload{}, 0, 0, err)
+		return err
+	}
+
+	started := time.Now().UTC()
+	if _, err := w.repo.Update(ctx, jobID, job.UpdateParams{
+		Status:    job.StatusRunning,
+		Stage:     StageGATKRunning,
+		StartedAt: &started,
+	}); err != nil {
+		return fmt.Errorf("gatk worker: mark running: %w", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, resolveTimeout(w.cfg.DefaultTimeout, p.TimeoutSeconds))
+	defer cancel()
+
+	stageStart := time.Now()
+	threads := choosePositive(p.Threads, w.cfg.DefaultThreads)
+	memMB := choosePositive(p.MemoryLimitMB, w.cfg.DefaultMemoryMB)
+	exitCode, runErr := w.runPipeline(runCtx, p, threads, memMB)
+	duration := time.Since(stageStart)
+
+	if runErr != nil {
+		if err := w.persistFailure(ctx, jobID, exitCode, p, threads, memMB, runErr); err != nil {
+			return fmt.Errorf("gatk worker: persist failure: %w", err)
+		}
+		w.observe("failure", classifyError(runErr, exitCode), duration)
+		w.log.Info().Str("job_id", msg.JobID).Str("stage", "gatk").Int("exit_code", exitCode).Dur("duration", duration).Msg("pipeline stage completed")
+		return nil
+	}
+
+	outRef, err := buildOutputRef(exitCode, duration, p, threads, memMB, "")
+	if err != nil {
+		return fmt.Errorf("gatk worker: output_ref: %w", err)
+	}
+	completed := time.Now().UTC()
+	if _, err := w.repo.Update(ctx, jobID, job.UpdateParams{
+		Status:      job.StatusSucceeded,
+		Stage:       StageGATKSucceeded,
+		CompletedAt: &completed,
+		OutputRef:   outRef,
+	}); err != nil {
+		return fmt.Errorf("gatk worker: mark success: %w", err)
+	}
+	w.observe("success", "", duration)
+	w.log.Info().Str("job_id", msg.JobID).Str("stage", "gatk").Int("exit_code", exitCode).Dur("duration", duration).Msg("pipeline stage completed")
+	return nil
+}
+
+func (w *Worker) runPipeline(ctx context.Context, p payload, threads, memMB int) (int, error) {
+	args := []string{
+		"--java-options", fmt.Sprintf("-Xmx%dM", memMB),
+		"HaplotypeCaller",
+		"-R", p.ReferencePath,
+		"-I", p.InputBAMPath,
+		"-O", p.OutputVCFPath,
+		"--native-pair-hmm-threads", fmt.Sprintf("%d", threads),
+	}
+	return w.runner.Run(ctx, "gatk", args...)
+}
+
+func (w *Worker) persistFailure(ctx context.Context, jobID uuid.UUID, exitCode int, p payload, threads, memMB int, runErr error) error {
+	outRef, err := buildOutputRef(exitCode, 0, p, threads, memMB, runErr.Error())
+	if err != nil {
+		return err
+	}
+	completed := time.Now().UTC()
+	_, err = w.repo.Update(ctx, jobID, job.UpdateParams{
+		Status:      job.StatusFailed,
+		Stage:       StageGATKFailed,
+		CompletedAt: &completed,
+		OutputRef:   outRef,
+	})
+	return err
+}
+
+func (w *Worker) observe(outcome, class string, duration time.Duration) {
+	if w.metrics == nil {
+		return
+	}
+	w.metrics.Observe("gatk", outcome, class, duration)
+}
+
+func decodePayload(raw json.RawMessage) (payload, error) {
+	var p payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return p, fmt.Errorf("gatk worker: decode payload: %w", err)
+	}
+	if p.ReferencePath == "" {
+		return p, errors.New("gatk worker: payload reference_path is required")
+	}
+	if p.InputBAMPath == "" {
+		return p, errors.New("gatk worker: payload input_bam_path is required")
+	}
+	if p.OutputVCFPath == "" {
+		return p, errors.New("gatk worker: payload output_vcf_path is required")
+	}
+	return p, nil
+}
+
+func choosePositive(v, fallback int) int {
+	if v > 0 {
+		return v
+	}
+	return fallback
+}
+
+func resolveTimeout(defaultTimeout time.Duration, timeoutSeconds int64) time.Duration {
+	if timeoutSeconds <= 0 {
+		return defaultTimeout
+	}
+	return time.Duration(timeoutSeconds) * time.Second
+}
+
+func classifyError(err error, exitCode int) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "payload"), strings.Contains(msg, "decode"), strings.Contains(msg, "required"), strings.Contains(msg, "invalid job id"):
+		return ErrorClassConfiguration
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return ErrorClassInfrastructure
+	case exitCode > 0:
+		return ErrorClassTool
+	default:
+		return ErrorClassInfrastructure
+	}
+}
+
+func buildOutputRef(exitCode int, duration time.Duration, p payload, threads, memMB int, errorMsg string) (json.RawMessage, error) {
+	m := map[string]any{
+		"kind":        "gatk_vcf_v1",
+		"exit_code":   exitCode,
+		"duration_ms": duration.Milliseconds(),
+		"limits": map[string]any{
+			"threads":         threads,
+			"memory_limit_mb": memMB,
+		},
+		"artifacts": map[string]any{
+			"vcf_path": p.OutputVCFPath,
+			"vcf_uri":  p.OutputVCFURI,
+		},
+	}
+	if errorMsg != "" {
+		m["error"] = errorMsg
+	}
+	return json.Marshal(m)
+}

--- a/backend/internal/pipeline/gatk/worker_test.go
+++ b/backend/internal/pipeline/gatk/worker_test.go
@@ -1,0 +1,201 @@
+package gatk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AminN77/senju/backend/internal/job"
+	"github.com/AminN77/senju/backend/internal/job/stub"
+	"github.com/AminN77/senju/backend/internal/platform/metrics"
+	"github.com/AminN77/senju/backend/internal/queue"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+type fakeRunner struct {
+	mu   sync.Mutex
+	run  func(ctx context.Context, name string, args ...string) (int, error)
+	call []runnerCall
+}
+
+type runnerCall struct {
+	name string
+	args []string
+}
+
+func (f *fakeRunner) Run(ctx context.Context, name string, args ...string) (int, error) {
+	f.mu.Lock()
+	f.call = append(f.call, runnerCall{name: name, args: append([]string(nil), args...)})
+	f.mu.Unlock()
+	return f.run(ctx, name, args...)
+}
+
+type recordingRepo struct{ base *stub.Repository }
+
+func newRecordingRepo() *recordingRepo { return &recordingRepo{base: stub.New()} }
+func (r *recordingRepo) Create(ctx context.Context, p job.CreateParams) (*job.Job, error) {
+	return r.base.Create(ctx, p)
+}
+func (r *recordingRepo) GetByID(ctx context.Context, id uuid.UUID) (*job.Job, error) {
+	return r.base.GetByID(ctx, id)
+}
+func (r *recordingRepo) Update(ctx context.Context, id uuid.UUID, p job.UpdateParams) (*job.Job, error) {
+	return r.base.Update(ctx, id, p)
+}
+
+func TestWorkerHandle_SuccessPersistsVCFAndTransitions(t *testing.T) {
+	t.Parallel()
+	repo := newRecordingRepo()
+	created, err := repo.Create(context.Background(), job.CreateParams{Status: job.StatusPending, Stage: "queued"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeRunner{run: func(_ context.Context, _ string, _ ...string) (int, error) { return 0, nil }}
+	w, err := NewWorker(repo, runner, zerolog.Nop(), Config{DefaultTimeout: time.Second, DefaultThreads: 8, DefaultMemoryMB: 4096}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"reference_path":"/ref.fa","input_bam_path":"/x.bam","output_vcf_path":"/x.vcf","output_vcf_uri":"s3://bucket/x.vcf"}`
+	if err := w.Handle(context.Background(), queue.Message{JobID: created.ID.String(), Payload: json.RawMessage(payload)}); err != nil {
+		t.Fatalf("handle err: %v", err)
+	}
+	updated, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Stage != StageGATKSucceeded || updated.Status != job.StatusSucceeded {
+		t.Fatalf("job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"vcf_uri":"s3://bucket/x.vcf"`)) {
+		t.Fatalf("output_ref %s", updated.OutputRef)
+	}
+}
+
+func TestWorkerHandle_ErrorClassificationAndFailurePersistence(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		payload        string
+		runner         func(ctx context.Context, name string, args ...string) (int, error)
+		wantClass      string
+		expectHandleEr bool
+	}{
+		{
+			name:           "configuration decode error",
+			payload:        `{"reference_path":"/ref.fa"}`,
+			runner:         func(_ context.Context, _ string, _ ...string) (int, error) { return 0, nil },
+			wantClass:      ErrorClassConfiguration,
+			expectHandleEr: true,
+		},
+		{
+			name:    "tool error",
+			payload: `{"reference_path":"/ref.fa","input_bam_path":"/x.bam","output_vcf_path":"/x.vcf"}`,
+			runner: func(_ context.Context, _ string, _ ...string) (int, error) {
+				return 2, errors.New("gatk failed")
+			},
+			wantClass:      ErrorClassTool,
+			expectHandleEr: false,
+		},
+		{
+			name:    "infrastructure timeout",
+			payload: `{"reference_path":"/ref.fa","input_bam_path":"/x.bam","output_vcf_path":"/x.vcf","timeout_seconds":1}`,
+			runner: func(_ context.Context, _ string, _ ...string) (int, error) {
+				return -1, context.DeadlineExceeded
+			},
+			wantClass:      ErrorClassInfrastructure,
+			expectHandleEr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := newRecordingRepo()
+			created, err := repo.Create(context.Background(), job.CreateParams{Status: job.StatusPending, Stage: "queued"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			m := NewMetrics()
+			w, err := NewWorker(repo, &fakeRunner{run: tt.runner}, zerolog.Nop(), Config{DefaultTimeout: time.Second}, m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			handleErr := w.Handle(context.Background(), queue.Message{JobID: created.ID.String(), Payload: json.RawMessage(tt.payload)})
+			if tt.expectHandleEr && handleErr == nil {
+				t.Fatal("expected handle error")
+			}
+			if !tt.expectHandleEr && handleErr != nil {
+				t.Fatalf("unexpected handle error: %v", handleErr)
+			}
+			updated, err := repo.GetByID(context.Background(), created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if updated.Stage != StageGATKFailed || updated.Status != job.StatusFailed {
+				t.Fatalf("job %+v", updated)
+			}
+			if !bytes.Contains(updated.OutputRef, []byte(`"error"`)) {
+				t.Fatalf("output_ref %s", updated.OutputRef)
+			}
+			class := classifyError(handleErr, 2)
+			if !tt.expectHandleEr {
+				// For terminal persisted runtime failures, handler returns nil by design.
+				class = tt.wantClass
+			}
+			if class != tt.wantClass {
+				t.Fatalf("class got=%s want=%s", class, tt.wantClass)
+			}
+		})
+	}
+}
+
+func TestWorkerHandle_ExportsPrometheusMetrics(t *testing.T) {
+	t.Parallel()
+	repo := newRecordingRepo()
+	created, err := repo.Create(context.Background(), job.CreateParams{Status: job.StatusPending, Stage: "queued"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageMetrics := NewMetrics()
+	reg := metrics.NewRegistry()
+	for _, c := range stageMetrics.Collectors() {
+		reg.MustRegister(c)
+	}
+	runner := &fakeRunner{run: func(_ context.Context, _ string, _ ...string) (int, error) { return 0, nil }}
+	w, err := NewWorker(repo, runner, zerolog.Nop(), Config{DefaultTimeout: time.Second}, stageMetrics)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"reference_path":"/ref.fa","input_bam_path":"/x.bam","output_vcf_path":"/x.vcf"}`
+	if err := w.Handle(context.Background(), queue.Message{JobID: created.ID.String(), Payload: json.RawMessage(payload)}); err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(reg.Handler())
+	t.Cleanup(srv.Close)
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "senju_pipeline_stage_duration_seconds") {
+		t.Fatalf("metrics missing duration: %s", text)
+	}
+	if !strings.Contains(text, "stage=\"gatk\"") || !strings.Contains(text, "outcome=\"success\"") {
+		t.Fatalf("metrics missing labels: %s", text)
+	}
+}

--- a/backend/internal/pipeline/gatk/worker_test.go
+++ b/backend/internal/pipeline/gatk/worker_test.go
@@ -94,7 +94,7 @@ func TestWorkerHandle_ErrorClassificationAndFailurePersistence(t *testing.T) {
 			payload:        `{"reference_path":"/ref.fa"}`,
 			runner:         func(_ context.Context, _ string, _ ...string) (int, error) { return 0, nil },
 			wantClass:      ErrorClassConfiguration,
-			expectHandleEr: true,
+			expectHandleEr: false,
 		},
 		{
 			name:    "tool error",
@@ -146,6 +146,9 @@ func TestWorkerHandle_ErrorClassificationAndFailurePersistence(t *testing.T) {
 			}
 			if !bytes.Contains(updated.OutputRef, []byte(`"error"`)) {
 				t.Fatalf("output_ref %s", updated.OutputRef)
+			}
+			if !bytes.Contains(updated.OutputRef, []byte(`"error_class":"`+tt.wantClass+`"`)) {
+				t.Fatalf("output_ref missing error_class: %s", updated.OutputRef)
 			}
 			class := classifyError(handleErr, 2)
 			if !tt.expectHandleEr {

--- a/docs/pipeline/nats-queue.md
+++ b/docs/pipeline/nats-queue.md
@@ -61,3 +61,14 @@ BWA + SAMtools alignment worker is implemented in `backend/internal/pipeline/ali
 - Stage-level CPU/memory limits are configurable per job (`threads`, `memory_limit_mb`) with safe defaults from worker config.
 - Deterministic output verification is documented and tested: same input/config and output bytes produce same SHA-256 checksum.
 - Stage logs include `job_id`, `stage=alignment`, `exit_code`, and `duration`.
+
+## GATK stage worker (Issue #12)
+
+GATK variant-calling worker is implemented in `backend/internal/pipeline/gatk`.
+
+- Payload fields: `reference_path`, `input_bam_path`, `output_vcf_path` (+ optional `output_vcf_uri`).
+- Worker executes `gatk HaplotypeCaller`, persists VCF artifact metadata in `output_ref`, and updates status transitions (`gatk_running` -> `gatk_succeeded` / `gatk_failed`).
+- Errors are classified into `tool`, `infrastructure`, and `configuration`.
+- Stage metrics are exported to Prometheus:
+  - `senju_pipeline_stage_duration_seconds` (histogram)
+  - `senju_pipeline_stage_total` (counter with `stage/outcome/error_class` labels)


### PR DESCRIPTION
## Summary
- Closes #12.
- Add `backend/internal/pipeline/gatk` worker to execute GATK HaplotypeCaller, persist VCF artifact metadata, and update pipeline status transitions (`gatk_running` -> `gatk_succeeded`/`gatk_failed`).
- Add explicit error classification (`tool`, `infrastructure`, `configuration`) and persist failure details in `output_ref`.
- Export stage metrics to Prometheus via `senju_pipeline_stage_duration_seconds` and `senju_pipeline_stage_total` with stage/outcome/error_class labels.

## Test evidence
- Ran `cd backend && golangci-lint run ./...` (pass).
- Ran `cd backend && go test ./...` (pass).
- Added tests in `backend/internal/pipeline/gatk/worker_test.go` covering:
  - successful VCF output persistence and status transitions
  - failure classification paths (configuration/tool/infrastructure)
  - Prometheus metric export for duration + terminal outcome

## Failure cases validated
- Invalid payload fields trigger classified configuration failure persistence.
- Tool non-zero exit triggers terminal failed state with tool classification.
- Timeout/deadline failures are classified as infrastructure.

## Rollback notes
- Revert this PR to remove GATK worker package and docs references.
- No schema/migration changes are introduced; rollback is code-only.
- Existing FastQC/alignment/queue behaviors remain unchanged.

## Test plan
- [x] `cd backend && golangci-lint run ./...`
- [x] `cd backend && go test ./...`
- [x] Validate Prometheus stage metric exposition via unit test
- [ ] Optional smoke: wire GATK worker into queue consumer process with local fixtures

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GATK HaplotypeCaller variant-calling worker to the pipeline (BAM→VCF).
  * Implemented error classification for failures: tool, infrastructure, configuration.
  * Exposed Prometheus metrics for stage duration and outcome totals.

* **Documentation**
  * Documented GATK worker configuration, required queue payload fields, and job status transitions.

* **Tests**
  * Added unit tests for success, failure classifications, and metrics export validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->