### PR TITLE
feat(api): variant query endpoint with filters and pagination (#14)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,12 @@ NATS_ADDR=localhost:4222
 
 # ClickHouse
 CLICKHOUSE_DB=senju
-CLICKHOUSE_USER=default
-CLICKHOUSE_PASSWORD=senju_dev_password
+# Optional explicit native DSN override for ClickHouse clients (variant query API). If empty, derived from CLICKHOUSE_* below.
+CLICKHOUSE_DSN=
 CLICKHOUSE_HTTP_PORT=8123
 CLICKHOUSE_NATIVE_PORT=9000
-# Optional explicit native DSN override for ClickHouse clients (variant query API). If empty, derived from CLICKHOUSE_* above.
-CLICKHOUSE_DSN=
+CLICKHOUSE_PASSWORD=senju_dev_password
+CLICKHOUSE_USER=default
 
 # MinIO
 MINIO_ROOT_USER=minioadmin

--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=senju_dev_password
 CLICKHOUSE_HTTP_PORT=8123
 CLICKHOUSE_NATIVE_PORT=9000
+# Optional explicit native DSN override for ClickHouse clients (variant query API). If empty, derived from CLICKHOUSE_* above.
+CLICKHOUSE_DSN=
 
 # MinIO
 MINIO_ROOT_USER=minioadmin

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@
 ## Variant analytics storage
 
 - ClickHouse variant schema and VCF ingestion loader: `docs/data/variants.md`
+- Variant query API with filters and pagination: `docs/api/variant-query.md`

--- a/backend/cmd/api/run.go
+++ b/backend/cmd/api/run.go
@@ -86,13 +86,20 @@ func run() error {
 	}
 
 	var variantQuery clickhouse.QueryService
+	var variantRepo *clickhouse.QueryRepository
 	if cfg.ClickHouseDSN != "" {
 		repo, err := clickhouse.OpenQueryRepository(cfg.ClickHouseDSN)
 		if err != nil {
 			return fmt.Errorf("clickhouse query repository: %w", err)
 		}
+		variantRepo = repo
 		variantQuery = repo
 	}
+	defer func() {
+		if variantRepo != nil {
+			_ = variantRepo.Close()
+		}
+	}()
 
 	engine := newEngine(log, runner, versionInfo(), promRegistry, jobRepo, objStore, variantQuery)
 	addr := listenAddr(cfg.APIPort)

--- a/backend/cmd/api/run.go
+++ b/backend/cmd/api/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/AminN77/senju/backend/internal/platform/logging"
 	"github.com/AminN77/senju/backend/internal/platform/metrics"
 	"github.com/AminN77/senju/backend/internal/probe/httpget"
+	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog"
@@ -84,7 +85,16 @@ func run() error {
 		objStore = s
 	}
 
-	engine := newEngine(log, runner, versionInfo(), promRegistry, jobRepo, objStore)
+	var variantQuery clickhouse.QueryService
+	if cfg.ClickHouseDSN != "" {
+		repo, err := clickhouse.OpenQueryRepository(cfg.ClickHouseDSN)
+		if err != nil {
+			return fmt.Errorf("clickhouse query repository: %w", err)
+		}
+		variantQuery = repo
+	}
+
+	engine := newEngine(log, runner, versionInfo(), promRegistry, jobRepo, objStore, variantQuery)
 	addr := listenAddr(cfg.APIPort)
 
 	srv := &http.Server{
@@ -150,7 +160,7 @@ func listenAddr(port int) string {
 	return ":" + strconv.Itoa(port)
 }
 
-func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry, jobs job.Repository, store objectstore.Service) *gin.Engine {
+func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry, jobs job.Repository, store objectstore.Service, variants clickhouse.QueryService) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(httpserver.RequestLogger(log))
@@ -162,6 +172,7 @@ func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver ht
 		Jobs:            jobs,
 		Log:             log,
 		ObjectStore:     store,
+		VariantQuery:    variants,
 	})
 	return r
 }

--- a/backend/cmd/api/run.go
+++ b/backend/cmd/api/run.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/AminN77/senju/backend/internal/api/variantquery"
 	"github.com/AminN77/senju/backend/internal/config"
 	"github.com/AminN77/senju/backend/internal/healthcheck"
 	"github.com/AminN77/senju/backend/internal/httpserver"
@@ -85,7 +86,7 @@ func run() error {
 		objStore = s
 	}
 
-	var variantQuery clickhouse.QueryService
+	var variantQuery variantquery.Service
 	var variantRepo *clickhouse.QueryRepository
 	if cfg.ClickHouseDSN != "" {
 		repo, err := clickhouse.OpenQueryRepository(cfg.ClickHouseDSN)
@@ -93,7 +94,7 @@ func run() error {
 			return fmt.Errorf("clickhouse query repository: %w", err)
 		}
 		variantRepo = repo
-		variantQuery = repo
+		variantQuery = clickhouseVariantQueryAdapter{svc: repo}
 	}
 	defer func() {
 		if variantRepo != nil {
@@ -167,7 +168,7 @@ func listenAddr(port int) string {
 	return ":" + strconv.Itoa(port)
 }
 
-func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry, jobs job.Repository, store objectstore.Service, variants clickhouse.QueryService) *gin.Engine {
+func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver httpserver.VersionInfo, prom *metrics.Registry, jobs job.Repository, store objectstore.Service, variants variantquery.Service) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(httpserver.RequestLogger(log))
@@ -182,6 +183,44 @@ func newEngine(log zerolog.Logger, readiness httpserver.ReadinessChecker, ver ht
 		VariantQuery:    variants,
 	})
 	return r
+}
+
+type clickhouseVariantQueryAdapter struct {
+	svc clickhouse.QueryService
+}
+
+func (a clickhouseVariantQueryAdapter) Query(ctx context.Context, f variantquery.QueryFilters) (variantquery.QueryResult, error) {
+	res, err := a.svc.Query(ctx, clickhouse.QueryFilters{
+		Chromosome:  f.Chromosome,
+		PositionMin: f.PositionMin,
+		PositionMax: f.PositionMax,
+		Gene:        f.Gene,
+		Page:        f.Page,
+		PageSize:    f.PageSize,
+	})
+	if err != nil {
+		return variantquery.QueryResult{}, err
+	}
+	rows := make([]variantquery.QueryRow, 0, len(res.Rows))
+	for _, r := range res.Rows {
+		rows = append(rows, variantquery.QueryRow{
+			Chromosome: r.Chromosome,
+			Position:   r.Position,
+			Ref:        r.Ref,
+			Alt:        r.Alt,
+			Qual:       r.Qual,
+			Filter:     r.Filter,
+			Info:       r.Info,
+			Gene:       r.Gene,
+		})
+	}
+	return variantquery.QueryResult{
+		Rows:     rows,
+		Total:    res.Total,
+		Page:     res.Page,
+		PageSize: res.PageSize,
+		HasNext:  res.HasNext,
+	}, nil
 }
 
 func parseShutdownTimeout(log zerolog.Logger) time.Duration {

--- a/backend/internal/api/variantquery/handler.go
+++ b/backend/internal/api/variantquery/handler.go
@@ -2,6 +2,7 @@
 package variantquery
 
 import (
+	"context"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -15,8 +16,13 @@ import (
 
 var safeToken = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
+// Service is the storage-agnostic dependency required by the handler.
+type Service interface {
+	Query(context.Context, clickhouse.QueryFilters) (clickhouse.QueryResult, error)
+}
+
 // Register mounts GET /variants on the given /v1 group.
-func Register(g *gin.RouterGroup, svc clickhouse.QueryService) {
+func Register(g *gin.RouterGroup, svc Service) {
 	if svc == nil {
 		g.GET("/variants", handleNoService)
 		return
@@ -56,7 +62,7 @@ type variantOut struct {
 	Gene       string   `json:"gene,omitempty"`
 }
 
-func handleQuery(svc clickhouse.QueryService) gin.HandlerFunc {
+func handleQuery(svc Service) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		filters, errs := parseFilters(c)
 		if len(errs) > 0 {
@@ -66,6 +72,7 @@ func handleQuery(svc clickhouse.QueryService) gin.HandlerFunc {
 		start := time.Now()
 		res, err := svc.Query(c.Request.Context(), filters)
 		if err != nil {
+			_ = c.Error(err)
 			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
 				Type:   problem.TypeInternalError,
 				Title:  "Internal error",

--- a/backend/internal/api/variantquery/handler.go
+++ b/backend/internal/api/variantquery/handler.go
@@ -1,0 +1,176 @@
+// Package variantquery registers the variant query HTTP API.
+package variantquery
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
+	"github.com/gin-gonic/gin"
+)
+
+var safeToken = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// Register mounts GET /variants on the given /v1 group.
+func Register(g *gin.RouterGroup, svc clickhouse.QueryService) {
+	if svc == nil {
+		g.GET("/variants", handleNoService)
+		return
+	}
+	g.GET("/variants", handleQuery(svc))
+}
+
+func handleNoService(c *gin.Context) {
+	problem.ServiceUnavailable(c, "Variant query service is not available; set CLICKHOUSE_DSN or CLICKHOUSE_* connection settings.")
+}
+
+type response struct {
+	Data       []variantOut `json:"data"`
+	Page       int          `json:"page"`
+	PageSize   int          `json:"page_size"`
+	Total      int64        `json:"total"`
+	HasNext    bool         `json:"has_next"`
+	LatencyMS  int64        `json:"latency_ms"`
+	AppliedFor filtersOut   `json:"filters"`
+}
+
+type filtersOut struct {
+	Chromosome  string  `json:"chromosome,omitempty"`
+	PositionMin *uint32 `json:"position_min,omitempty"`
+	PositionMax *uint32 `json:"position_max,omitempty"`
+	Gene        string  `json:"gene,omitempty"`
+}
+
+type variantOut struct {
+	Chromosome string   `json:"chromosome"`
+	Position   uint32   `json:"position"`
+	Ref        string   `json:"ref"`
+	Alt        string   `json:"alt"`
+	Qual       *float64 `json:"qual,omitempty"`
+	Filter     string   `json:"filter"`
+	Info       string   `json:"info"`
+	Gene       string   `json:"gene,omitempty"`
+}
+
+func handleQuery(svc clickhouse.QueryService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		filters, errs := parseFilters(c)
+		if len(errs) > 0 {
+			problem.Validation(c, "one or more fields failed validation", errs)
+			return
+		}
+		start := time.Now()
+		res, err := svc.Query(c.Request.Context(), filters)
+		if err != nil {
+			problem.JSON(c, http.StatusInternalServerError, problem.Problem{
+				Type:   problem.TypeInternalError,
+				Title:  "Internal error",
+				Status: http.StatusInternalServerError,
+				Detail: "could not query variants",
+			})
+			return
+		}
+		out := make([]variantOut, 0, len(res.Rows))
+		for _, r := range res.Rows {
+			out = append(out, variantOut{
+				Chromosome: r.Chromosome,
+				Position:   r.Position,
+				Ref:        r.Ref,
+				Alt:        r.Alt,
+				Qual:       r.Qual,
+				Filter:     r.Filter,
+				Info:       r.Info,
+				Gene:       r.Gene,
+			})
+		}
+		c.JSON(http.StatusOK, response{
+			Data:      out,
+			Page:      res.Page,
+			PageSize:  res.PageSize,
+			Total:     res.Total,
+			HasNext:   res.HasNext,
+			LatencyMS: time.Since(start).Milliseconds(),
+			AppliedFor: filtersOut{
+				Chromosome:  filters.Chromosome,
+				PositionMin: filters.PositionMin,
+				PositionMax: filters.PositionMax,
+				Gene:        filters.Gene,
+			},
+		})
+	}
+}
+
+func parseFilters(c *gin.Context) (clickhouse.QueryFilters, []problem.FieldError) {
+	var errs []problem.FieldError
+	chromosome := strings.TrimSpace(c.Query("chromosome"))
+	if chromosome != "" && !safeToken.MatchString(chromosome) {
+		errs = append(errs, problem.FieldError{Field: "chromosome", Message: "invalid"})
+	}
+
+	gene := strings.TrimSpace(c.Query("gene"))
+	if gene != "" && !safeToken.MatchString(gene) {
+		errs = append(errs, problem.FieldError{Field: "gene", Message: "invalid"})
+	}
+
+	posMin, err := parseOptUint32(c.Query("position_min"))
+	if err != nil {
+		errs = append(errs, problem.FieldError{Field: "position_min", Message: "invalid"})
+	}
+	posMax, err := parseOptUint32(c.Query("position_max"))
+	if err != nil {
+		errs = append(errs, problem.FieldError{Field: "position_max", Message: "invalid"})
+	}
+	if posMin != nil && posMax != nil && *posMin > *posMax {
+		errs = append(errs, problem.FieldError{Field: "position_range", Message: "invalid"})
+	}
+
+	page, err := parsePositiveInt(c.Query("page"), 1)
+	if err != nil {
+		errs = append(errs, problem.FieldError{Field: "page", Message: "invalid"})
+	}
+	pageSize, err := parsePositiveInt(c.Query("page_size"), 50)
+	if err != nil {
+		errs = append(errs, problem.FieldError{Field: "page_size", Message: "invalid"})
+	}
+	if pageSize > 200 {
+		errs = append(errs, problem.FieldError{Field: "page_size", Message: "max_200"})
+	}
+
+	return clickhouse.QueryFilters{
+		Chromosome:  chromosome,
+		PositionMin: posMin,
+		PositionMax: posMax,
+		Gene:        gene,
+		Page:        page,
+		PageSize:    pageSize,
+	}, errs
+}
+
+func parsePositiveInt(raw string, def int) (int, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 1 {
+		return 0, strconv.ErrSyntax
+	}
+	return n, nil
+}
+
+func parseOptUint32(raw string) (*uint32, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil, nil
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return nil, err
+	}
+	u := uint32(n)
+	return &u, nil
+}

--- a/backend/internal/api/variantquery/handler.go
+++ b/backend/internal/api/variantquery/handler.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/AminN77/senju/backend/internal/api/problem"
-	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
 	"github.com/gin-gonic/gin"
 )
 
@@ -18,7 +17,38 @@ var safeToken = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 // Service is the storage-agnostic dependency required by the handler.
 type Service interface {
-	Query(context.Context, clickhouse.QueryFilters) (clickhouse.QueryResult, error)
+	Query(context.Context, QueryFilters) (QueryResult, error)
+}
+
+// QueryFilters controls variant search predicates and pagination.
+type QueryFilters struct {
+	Chromosome  string
+	PositionMin *uint32
+	PositionMax *uint32
+	Gene        string
+	Page        int
+	PageSize    int
+}
+
+// QueryRow is one variant returned by the query service.
+type QueryRow struct {
+	Chromosome string
+	Position   uint32
+	Ref        string
+	Alt        string
+	Qual       *float64
+	Filter     string
+	Info       string
+	Gene       string
+}
+
+// QueryResult is a paginated variant page.
+type QueryResult struct {
+	Rows     []QueryRow
+	Total    int64
+	Page     int
+	PageSize int
+	HasNext  bool
 }
 
 // Register mounts GET /variants on the given /v1 group.
@@ -83,16 +113,7 @@ func handleQuery(svc Service) gin.HandlerFunc {
 		}
 		out := make([]variantOut, 0, len(res.Rows))
 		for _, r := range res.Rows {
-			out = append(out, variantOut{
-				Chromosome: r.Chromosome,
-				Position:   r.Position,
-				Ref:        r.Ref,
-				Alt:        r.Alt,
-				Qual:       r.Qual,
-				Filter:     r.Filter,
-				Info:       r.Info,
-				Gene:       r.Gene,
-			})
+			out = append(out, variantOut(r))
 		}
 		c.JSON(http.StatusOK, response{
 			Data:      out,
@@ -111,7 +132,7 @@ func handleQuery(svc Service) gin.HandlerFunc {
 	}
 }
 
-func parseFilters(c *gin.Context) (clickhouse.QueryFilters, []problem.FieldError) {
+func parseFilters(c *gin.Context) (QueryFilters, []problem.FieldError) {
 	var errs []problem.FieldError
 	chromosome := strings.TrimSpace(c.Query("chromosome"))
 	if chromosome != "" && !safeToken.MatchString(chromosome) {
@@ -147,7 +168,7 @@ func parseFilters(c *gin.Context) (clickhouse.QueryFilters, []problem.FieldError
 		errs = append(errs, problem.FieldError{Field: "page_size", Message: "max_200"})
 	}
 
-	return clickhouse.QueryFilters{
+	return QueryFilters{
 		Chromosome:  chromosome,
 		PositionMin: posMin,
 		PositionMax: posMax,

--- a/backend/internal/api/variantquery/handler_test.go
+++ b/backend/internal/api/variantquery/handler_test.go
@@ -10,20 +10,19 @@ import (
 	"testing"
 
 	"github.com/AminN77/senju/backend/internal/api/problem"
-	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
 	"github.com/gin-gonic/gin"
 )
 
 type fakeService struct {
-	gotFilters clickhouse.QueryFilters
-	res        clickhouse.QueryResult
+	gotFilters QueryFilters
+	res        QueryResult
 	err        error
 }
 
-func (f *fakeService) Query(_ context.Context, filters clickhouse.QueryFilters) (clickhouse.QueryResult, error) {
+func (f *fakeService) Query(_ context.Context, filters QueryFilters) (QueryResult, error) {
 	f.gotFilters = filters
 	if f.err != nil {
-		return clickhouse.QueryResult{}, f.err
+		return QueryResult{}, f.err
 	}
 	return f.res, nil
 }
@@ -32,8 +31,8 @@ func TestGetVariants_200(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 	svc := &fakeService{
-		res: clickhouse.QueryResult{
-			Rows: []clickhouse.QueryRow{
+		res: QueryResult{
+			Rows: []QueryRow{
 				{Chromosome: "chr1", Position: 123, Ref: "A", Alt: "G", Filter: "PASS", Info: "GENE=TP53", Gene: "TP53"},
 			},
 			Total:    1,

--- a/backend/internal/api/variantquery/handler_test.go
+++ b/backend/internal/api/variantquery/handler_test.go
@@ -84,6 +84,34 @@ func TestGetVariants_400_Validation(t *testing.T) {
 	}
 }
 
+func TestGetVariants_400_PositionRangeInvalid(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1"), &fakeService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants?position_min=100&position_max=50", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var p problem.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, e := range p.Errors {
+		if e.Field == "position_range" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected position_range error, got %+v", p.Errors)
+	}
+}
+
 func TestGetVariants_500_QueryError(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/api/variantquery/handler_test.go
+++ b/backend/internal/api/variantquery/handler_test.go
@@ -1,0 +1,114 @@
+package variantquery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/AminN77/senju/backend/internal/api/problem"
+	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
+	"github.com/gin-gonic/gin"
+)
+
+type fakeService struct {
+	gotFilters clickhouse.QueryFilters
+	res        clickhouse.QueryResult
+	err        error
+}
+
+func (f *fakeService) Query(_ context.Context, filters clickhouse.QueryFilters) (clickhouse.QueryResult, error) {
+	f.gotFilters = filters
+	if f.err != nil {
+		return clickhouse.QueryResult{}, f.err
+	}
+	return f.res, nil
+}
+
+func TestGetVariants_200(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	svc := &fakeService{
+		res: clickhouse.QueryResult{
+			Rows: []clickhouse.QueryRow{
+				{Chromosome: "chr1", Position: 123, Ref: "A", Alt: "G", Filter: "PASS", Info: "GENE=TP53", Gene: "TP53"},
+			},
+			Total:    1,
+			Page:     2,
+			PageSize: 10,
+			HasNext:  false,
+		},
+	}
+	r := gin.New()
+	Register(r.Group("/v1"), svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants?chromosome=chr1&gene=TP53&page=2&page_size=10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	if svc.gotFilters.Chromosome != "chr1" || svc.gotFilters.Gene != "TP53" {
+		t.Fatalf("filters %+v", svc.gotFilters)
+	}
+	var got response
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Total != 1 || len(got.Data) != 1 || got.Data[0].Gene != "TP53" {
+		t.Fatalf("response %+v", got)
+	}
+}
+
+func TestGetVariants_400_Validation(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1"), &fakeService{})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants?chromosome=chr1;DROP&page=0&page_size=1000&position_min=abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status %d body %s", w.Code, w.Body.String())
+	}
+	var p problem.Problem
+	if err := json.Unmarshal(w.Body.Bytes(), &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.Type != problem.TypeValidationError || len(p.Errors) == 0 {
+		t.Fatalf("problem %+v", p)
+	}
+}
+
+func TestGetVariants_500_QueryError(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1"), &fakeService{err: errors.New("boom")})
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d", w.Code)
+	}
+}
+
+func TestGetVariants_503_NoService(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	Register(r.Group("/v1"), nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Variant query service is not available") {
+		t.Fatalf("body %s", w.Body.String())
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	PostgresDSN    string
 	ClickHousePing string
+	ClickHouseDSN  string
 	MinIOHealthURL string
 	NATSAddr       string
 
@@ -73,6 +74,10 @@ func Load() (Config, error) {
 	if chBase != "" {
 		chPing = chBase + "/ping"
 	}
+	chDSN, err := clickHouseDSN(chBase)
+	if err != nil {
+		return Config{}, err
+	}
 
 	region := strings.TrimSpace(os.Getenv("S3_REGION"))
 	if region == "" {
@@ -115,6 +120,7 @@ func Load() (Config, error) {
 		LogLevel:       os.Getenv("LOG_LEVEL"),
 		PostgresDSN:    postgresDSN(),
 		ClickHousePing: chPing,
+		ClickHouseDSN:  chDSN,
 		MinIOHealthURL: strings.TrimSpace(os.Getenv("MINIO_HEALTH_URL")),
 		NATSAddr:       strings.TrimSpace(os.Getenv("NATS_ADDR")),
 		ObjectStore: ObjectStoreConfig{
@@ -134,6 +140,35 @@ func Load() (Config, error) {
 			BackoffBase:  queueBackoffBase,
 		},
 	}, nil
+}
+
+func clickHouseDSN(chBase string) (string, error) {
+	if dsn := strings.TrimSpace(os.Getenv("CLICKHOUSE_DSN")); dsn != "" {
+		return dsn, nil
+	}
+	if chBase == "" {
+		return "", nil
+	}
+	u, err := url.Parse(chBase)
+	if err != nil {
+		return "", fmt.Errorf("CLICKHOUSE_HTTP_URL: parse: %w", err)
+	}
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return "", errors.New("CLICKHOUSE_HTTP_URL: hostname is required")
+	}
+	port := getenvDefaultTrim("CLICKHOUSE_NATIVE_PORT", "9000")
+	user := getenvDefaultTrim("CLICKHOUSE_USER", "default")
+	pass := strings.TrimSpace(os.Getenv("CLICKHOUSE_PASSWORD"))
+	db := getenvDefaultTrim("CLICKHOUSE_DB", "default")
+
+	out := &url.URL{
+		Scheme: "clickhouse",
+		User:   url.UserPassword(user, pass),
+		Host:   net.JoinHostPort(host, port),
+		Path:   "/" + db,
+	}
+	return out.String(), nil
 }
 
 func postgresDSN() string {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -76,6 +76,7 @@ func TestLoad_ClickHousePingOnlyWhenBaseSet(t *testing.T) {
 
 	t.Run("empty base", func(t *testing.T) {
 		t.Setenv("CLICKHOUSE_HTTP_URL", "")
+		t.Setenv("CLICKHOUSE_DSN", "")
 		cfg, err := Load()
 		if err != nil {
 			t.Fatal(err)
@@ -83,16 +84,39 @@ func TestLoad_ClickHousePingOnlyWhenBaseSet(t *testing.T) {
 		if cfg.ClickHousePing != "" {
 			t.Fatalf("got %q", cfg.ClickHousePing)
 		}
+		if cfg.ClickHouseDSN != "" {
+			t.Fatalf("got %q", cfg.ClickHouseDSN)
+		}
 	})
 
 	t.Run("with base", func(t *testing.T) {
 		t.Setenv("CLICKHOUSE_HTTP_URL", "http://localhost:8123")
+		t.Setenv("CLICKHOUSE_NATIVE_PORT", "9000")
+		t.Setenv("CLICKHOUSE_USER", "default")
+		t.Setenv("CLICKHOUSE_PASSWORD", "pass")
+		t.Setenv("CLICKHOUSE_DB", "senju")
+		t.Setenv("CLICKHOUSE_DSN", "")
 		cfg, err := Load()
 		if err != nil {
 			t.Fatal(err)
 		}
 		if want := "http://localhost:8123/ping"; cfg.ClickHousePing != want {
 			t.Fatalf("got %q want %q", cfg.ClickHousePing, want)
+		}
+		if !strings.Contains(cfg.ClickHouseDSN, "clickhouse://default:pass@localhost:9000/senju") {
+			t.Fatalf("dsn %q", cfg.ClickHouseDSN)
+		}
+	})
+
+	t.Run("explicit dsn overrides base", func(t *testing.T) {
+		t.Setenv("CLICKHOUSE_HTTP_URL", "http://localhost:8123")
+		t.Setenv("CLICKHOUSE_DSN", "clickhouse://u:p@localhost:9000/db")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.ClickHouseDSN != "clickhouse://u:p@localhost:9000/db" {
+			t.Fatalf("dsn %q", cfg.ClickHouseDSN)
 		}
 	})
 }

--- a/backend/internal/httpserver/router.go
+++ b/backend/internal/httpserver/router.go
@@ -16,7 +16,6 @@ import (
 	"github.com/AminN77/senju/backend/internal/healthcheck"
 	"github.com/AminN77/senju/backend/internal/job"
 	"github.com/AminN77/senju/backend/internal/objectstore"
-	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
@@ -41,8 +40,8 @@ type Options struct {
 	Log zerolog.Logger
 	// ObjectStore enables multipart presigned uploads under /v1/objects. If nil, those routes return 503.
 	ObjectStore objectstore.Service
-	// VariantQuery serves variant analytics reads from ClickHouse. If nil, /v1/variants returns 503.
-	VariantQuery clickhouse.QueryService
+	// VariantQuery serves variant analytics reads. If nil, /v1/variants returns 503.
+	VariantQuery variantquery.Service
 }
 
 // VersionInfo is returned by GET /version.

--- a/backend/internal/httpserver/router.go
+++ b/backend/internal/httpserver/router.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/AminN77/senju/backend/internal/api/fastqupload"
 	"github.com/AminN77/senju/backend/internal/api/objectupload"
+	"github.com/AminN77/senju/backend/internal/api/variantquery"
 	"github.com/AminN77/senju/backend/internal/healthcheck"
 	"github.com/AminN77/senju/backend/internal/job"
 	"github.com/AminN77/senju/backend/internal/objectstore"
+	"github.com/AminN77/senju/backend/internal/variant/clickhouse"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 )
@@ -39,6 +41,8 @@ type Options struct {
 	Log zerolog.Logger
 	// ObjectStore enables multipart presigned uploads under /v1/objects. If nil, those routes return 503.
 	ObjectStore objectstore.Service
+	// VariantQuery serves variant analytics reads from ClickHouse. If nil, /v1/variants returns 503.
+	VariantQuery clickhouse.QueryService
 }
 
 // VersionInfo is returned by GET /version.
@@ -65,6 +69,7 @@ func Register(r *gin.Engine, opts Options) {
 	r.GET("/metrics", gin.WrapH(opts.Metrics))
 	fastqupload.Register(r.Group("/v1/jobs"), opts.Jobs)
 	objectupload.Register(r.Group("/v1/objects"), opts.ObjectStore, opts.Log)
+	variantquery.Register(r.Group("/v1"), opts.VariantQuery)
 	registerOpenAPISpecRoute(r)
 	if opts.EnableSwaggerUI {
 		registerSwaggerUIRoute(r)

--- a/backend/internal/variant/clickhouse/query.go
+++ b/backend/internal/variant/clickhouse/query.go
@@ -160,11 +160,12 @@ func extractGene(info string) string {
 	parts := strings.Split(info, ";")
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
-		if strings.HasPrefix(strings.ToUpper(p), "GENE=") {
-			return strings.TrimSpace(strings.TrimPrefix(p, "GENE="))
+		up := strings.ToUpper(p)
+		if strings.HasPrefix(up, "GENE=") {
+			return strings.TrimSpace(p[len("GENE="):])
 		}
-		if strings.HasPrefix(strings.ToUpper(p), "GENE_SYMBOL=") {
-			return strings.TrimSpace(strings.TrimPrefix(p, "GENE_SYMBOL="))
+		if strings.HasPrefix(up, "GENE_SYMBOL=") {
+			return strings.TrimSpace(p[len("GENE_SYMBOL="):])
 		}
 	}
 	return ""

--- a/backend/internal/variant/clickhouse/query.go
+++ b/backend/internal/variant/clickhouse/query.go
@@ -1,0 +1,163 @@
+package clickhouse
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+// QueryFilters controls variant search predicates and pagination.
+type QueryFilters struct {
+	Chromosome  string
+	PositionMin *uint32
+	PositionMax *uint32
+	Gene        string
+	Page        int
+	PageSize    int
+}
+
+// QueryRow is one variant returned to the API layer.
+type QueryRow struct {
+	Chromosome string
+	Position   uint32
+	Ref        string
+	Alt        string
+	Qual       *float64
+	Filter     string
+	Info       string
+	Gene       string
+}
+
+// QueryResult is a paginated variant page.
+type QueryResult struct {
+	Rows     []QueryRow
+	Total    int64
+	Page     int
+	PageSize int
+	HasNext  bool
+}
+
+// QueryService is consumed by HTTP handlers for variant retrieval.
+type QueryService interface {
+	Query(context.Context, QueryFilters) (QueryResult, error)
+}
+
+// QueryRepository executes variant queries against ClickHouse.
+type QueryRepository struct {
+	db *sql.DB
+}
+
+// NewQueryRepository builds a query repository from an existing DB handle.
+func NewQueryRepository(db *sql.DB) (*QueryRepository, error) {
+	if db == nil {
+		return nil, errors.New("clickhouse query repository: db is nil")
+	}
+	return &QueryRepository{db: db}, nil
+}
+
+// OpenQueryRepository creates a query repository from a ClickHouse DSN.
+func OpenQueryRepository(dsn string) (*QueryRepository, error) {
+	l, err := Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return NewQueryRepository(l.db)
+}
+
+// Query returns a filtered/paginated variants page.
+func (r *QueryRepository) Query(ctx context.Context, f QueryFilters) (QueryResult, error) {
+	if f.Page < 1 {
+		f.Page = 1
+	}
+	if f.PageSize < 1 {
+		f.PageSize = 50
+	}
+	whereSQL, args := buildWhere(f)
+
+	var total int64
+	countSQL := "SELECT count() FROM variants" + whereSQL
+	if err := r.db.QueryRowContext(ctx, countSQL, args...).Scan(&total); err != nil {
+		return QueryResult{}, err
+	}
+
+	offset := (f.Page - 1) * f.PageSize
+	// #nosec G202 -- whereSQL is assembled from constant clauses with parameter placeholders only.
+	q := `
+SELECT chrom, pos, ref, alt, qual, filter, info
+FROM variants` + whereSQL + `
+ORDER BY chrom, pos, ref, alt
+LIMIT ? OFFSET ?`
+	queryArgs := append(append([]any{}, args...), f.PageSize, offset)
+
+	rows, err := r.db.QueryContext(ctx, q, queryArgs...)
+	if err != nil {
+		return QueryResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make([]QueryRow, 0, f.PageSize)
+	for rows.Next() {
+		var rr QueryRow
+		var qual sql.NullFloat64
+		if err := rows.Scan(&rr.Chromosome, &rr.Position, &rr.Ref, &rr.Alt, &qual, &rr.Filter, &rr.Info); err != nil {
+			return QueryResult{}, err
+		}
+		if qual.Valid {
+			qv := qual.Float64
+			rr.Qual = &qv
+		}
+		rr.Gene = extractGene(rr.Info)
+		out = append(out, rr)
+	}
+	if err := rows.Err(); err != nil {
+		return QueryResult{}, err
+	}
+
+	return QueryResult{
+		Rows:     out,
+		Total:    total,
+		Page:     f.Page,
+		PageSize: f.PageSize,
+		HasNext:  int64(offset+len(out)) < total,
+	}, nil
+}
+
+func buildWhere(f QueryFilters) (string, []any) {
+	clauses := make([]string, 0, 4)
+	args := make([]any, 0, 4)
+	if c := strings.TrimSpace(f.Chromosome); c != "" {
+		clauses = append(clauses, "chrom = ?")
+		args = append(args, c)
+	}
+	if f.PositionMin != nil {
+		clauses = append(clauses, "pos >= ?")
+		args = append(args, *f.PositionMin)
+	}
+	if f.PositionMax != nil {
+		clauses = append(clauses, "pos <= ?")
+		args = append(args, *f.PositionMax)
+	}
+	if g := strings.TrimSpace(f.Gene); g != "" {
+		clauses = append(clauses, "lower(info) LIKE ?")
+		args = append(args, "%gene="+strings.ToLower(g)+"%")
+	}
+	if len(clauses) == 0 {
+		return "", args
+	}
+	return " WHERE " + strings.Join(clauses, " AND "), args
+}
+
+func extractGene(info string) string {
+	parts := strings.Split(info, ";")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if strings.HasPrefix(strings.ToUpper(p), "GENE=") {
+			return strings.TrimSpace(strings.TrimPrefix(p, "GENE="))
+		}
+		if strings.HasPrefix(strings.ToUpper(p), "GENE_SYMBOL=") {
+			return strings.TrimSpace(strings.TrimPrefix(p, "GENE_SYMBOL="))
+		}
+	}
+	return ""
+}

--- a/backend/internal/variant/clickhouse/query.go
+++ b/backend/internal/variant/clickhouse/query.go
@@ -45,7 +45,8 @@ type QueryService interface {
 
 // QueryRepository executes variant queries against ClickHouse.
 type QueryRepository struct {
-	db *sql.DB
+	db     *sql.DB
+	ownsDB bool
 }
 
 // NewQueryRepository builds a query repository from an existing DB handle.
@@ -53,7 +54,7 @@ func NewQueryRepository(db *sql.DB) (*QueryRepository, error) {
 	if db == nil {
 		return nil, errors.New("clickhouse query repository: db is nil")
 	}
-	return &QueryRepository{db: db}, nil
+	return &QueryRepository{db: db, ownsDB: false}, nil
 }
 
 // OpenQueryRepository creates a query repository from a ClickHouse DSN.
@@ -62,12 +63,15 @@ func OpenQueryRepository(dsn string) (*QueryRepository, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewQueryRepository(l.db)
+	return &QueryRepository{db: l.db, ownsDB: true}, nil
 }
 
 // Close releases the underlying ClickHouse connection pool.
 func (r *QueryRepository) Close() error {
 	if r == nil || r.db == nil {
+		return nil
+	}
+	if !r.ownsDB {
 		return nil
 	}
 	return r.db.Close()

--- a/backend/internal/variant/clickhouse/query.go
+++ b/backend/internal/variant/clickhouse/query.go
@@ -65,6 +65,14 @@ func OpenQueryRepository(dsn string) (*QueryRepository, error) {
 	return NewQueryRepository(l.db)
 }
 
+// Close releases the underlying ClickHouse connection pool.
+func (r *QueryRepository) Close() error {
+	if r == nil || r.db == nil {
+		return nil
+	}
+	return r.db.Close()
+}
+
 // Query returns a filtered/paginated variants page.
 func (r *QueryRepository) Query(ctx context.Context, f QueryFilters) (QueryResult, error) {
 	if f.Page < 1 {

--- a/backend/internal/variant/clickhouse/query.go
+++ b/backend/internal/variant/clickhouse/query.go
@@ -147,8 +147,9 @@ func buildWhere(f QueryFilters) (string, []any) {
 		args = append(args, *f.PositionMax)
 	}
 	if g := strings.TrimSpace(f.Gene); g != "" {
-		clauses = append(clauses, "lower(info) LIKE ?")
-		args = append(args, "%gene="+strings.ToLower(g)+"%")
+		lg := strings.ToLower(g)
+		clauses = append(clauses, "(lower(info) LIKE ? OR lower(info) LIKE ?)")
+		args = append(args, "%gene="+lg+"%", "%gene_symbol="+lg+"%")
 	}
 	if len(clauses) == 0 {
 		return "", args

--- a/backend/internal/variant/clickhouse/query_test.go
+++ b/backend/internal/variant/clickhouse/query_test.go
@@ -26,7 +26,7 @@ func TestBuildWhere(t *testing.T) {
 	if !strings.Contains(sql, "chrom = ?") || !strings.Contains(sql, "pos >= ?") || !strings.Contains(sql, "lower(info) LIKE ?") {
 		t.Fatalf("where %q", sql)
 	}
-	if len(args) != 4 {
+	if len(args) != 5 {
 		t.Fatalf("args %+v", args)
 	}
 }
@@ -35,6 +35,9 @@ func TestExtractGene(t *testing.T) {
 	t.Parallel()
 	if got := extractGene("DP=10;GENE=TP53;AF=0.2"); got != "TP53" {
 		t.Fatalf("gene %q", got)
+	}
+	if got := extractGene("DP=10;GENE_SYMBOL=BRCA1;AF=0.2"); got != "BRCA1" {
+		t.Fatalf("gene symbol %q", got)
 	}
 }
 

--- a/backend/internal/variant/clickhouse/query_test.go
+++ b/backend/internal/variant/clickhouse/query_test.go
@@ -1,0 +1,177 @@
+package clickhouse
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestBuildWhere(t *testing.T) {
+	t.Parallel()
+	posMin := uint32(10)
+	posMax := uint32(20)
+	sql, args := buildWhere(QueryFilters{
+		Chromosome:  "chr1",
+		PositionMin: &posMin,
+		PositionMax: &posMax,
+		Gene:        "TP53",
+	})
+	if !strings.Contains(sql, "chrom = ?") || !strings.Contains(sql, "pos >= ?") || !strings.Contains(sql, "lower(info) LIKE ?") {
+		t.Fatalf("where %q", sql)
+	}
+	if len(args) != 4 {
+		t.Fatalf("args %+v", args)
+	}
+}
+
+func TestExtractGene(t *testing.T) {
+	t.Parallel()
+	if got := extractGene("DP=10;GENE=TP53;AF=0.2"); got != "TP53" {
+		t.Fatalf("gene %q", got)
+	}
+}
+
+func TestQueryRepository_IntegrationFiltersAndPagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+	dsn := strings.TrimSpace(os.Getenv("CLICKHOUSE_DSN"))
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	loader, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = loader.Close() }()
+	if err := loader.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewQueryRepository(loader.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chrom := "chr14_" + uuid.NewString()[:8]
+	if err := seedVariantsForTests(ctx, loader.db, chrom, 300); err != nil {
+		t.Fatal(err)
+	}
+
+	posMin := uint32(50)
+	posMax := uint32(200)
+	res, err := repo.Query(ctx, QueryFilters{
+		Chromosome:  chrom,
+		PositionMin: &posMin,
+		PositionMax: &posMax,
+		Gene:        "TP53",
+		Page:        1,
+		PageSize:    25,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatal("expected rows")
+	}
+	if res.Total == 0 {
+		t.Fatal("expected total")
+	}
+	for _, row := range res.Rows {
+		if row.Chromosome != chrom {
+			t.Fatalf("chrom %q", row.Chromosome)
+		}
+		if row.Position < posMin || row.Position > posMax {
+			t.Fatalf("position %d out of range", row.Position)
+		}
+		if !strings.EqualFold(row.Gene, "TP53") {
+			t.Fatalf("gene %q", row.Gene)
+		}
+	}
+}
+
+func TestQueryRepository_P95Under500ms(t *testing.T) {
+	if testing.Short() || os.Getenv("CI") != "" {
+		t.Skip("performance threshold is environment-dependent")
+	}
+	dsn := strings.TrimSpace(os.Getenv("CLICKHOUSE_DSN"))
+	if dsn == "" {
+		t.Skip("CLICKHOUSE_DSN not set")
+	}
+	ctx := context.Background()
+	loader, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = loader.Close() }()
+	if err := loader.EnsureSchema(ctx); err != nil {
+		t.Fatal(err)
+	}
+	repo, err := NewQueryRepository(loader.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chrom := "chr14perf_" + uuid.NewString()[:8]
+	if err := seedVariantsForTests(ctx, loader.db, chrom, 5000); err != nil {
+		t.Fatal(err)
+	}
+	const samples = 200
+	lat := make([]time.Duration, 0, samples)
+	for i := 0; i < samples; i++ {
+		start := time.Now()
+		_, err := repo.Query(ctx, QueryFilters{
+			Chromosome: chrom,
+			Page:       1,
+			PageSize:   50,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		lat = append(lat, time.Since(start))
+	}
+	sort.Slice(lat, func(i, j int) bool { return lat[i] < lat[j] })
+	p95 := lat[int(float64(len(lat))*0.95)]
+	if p95 > 500*time.Millisecond {
+		t.Fatalf("p95 latency %s exceeds 500ms", p95)
+	}
+}
+
+func seedVariantsForTests(ctx context.Context, db *sql.DB, chrom string, rows int) error {
+	parts := make([]string, 0, rows)
+	args := make([]any, 0, rows*9)
+	for i := 1; i <= rows; i++ {
+		gene := "GENE=BRCA1"
+		if i%2 == 0 {
+			gene = "GENE=TP53"
+		}
+		parts = append(parts, "(?, ?, ?, ?, ?, ?, ?, ?, ?)")
+		args = append(args,
+			"test_dataset",
+			chrom,
+			uint32(i),
+			"A",
+			"G",
+			float64(50),
+			"PASS",
+			"DP=10;"+gene,
+			uuid.NewString(),
+		)
+	}
+	q := `
+INSERT INTO variants (dataset_id, chrom, pos, ref, alt, qual, filter, info, source_key)
+VALUES ` + strings.Join(parts, ",")
+	// #nosec G202 -- placeholders are generated from constant tuple tokens only.
+	_, err := db.ExecContext(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("seed variants: %w", err)
+	}
+	return nil
+}

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -318,6 +318,80 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetails"
+  /v1/variants:
+    get:
+      tags:
+        - Ingestion
+      summary: Query variants with filters and pagination
+      description: |
+        Queries variant rows stored in ClickHouse with optional chromosome, position range, and gene filters.
+        Supports page-based pagination.
+      operationId: getVariants
+      parameters:
+        - name: chromosome
+          in: query
+          schema:
+            type: string
+          description: Exact chromosome value (example `chr1`).
+        - name: position_min
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+          description: Inclusive lower bound for position.
+        - name: position_max
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+          description: Inclusive upper bound for position.
+        - name: gene
+          in: query
+          schema:
+            type: string
+          description: Gene symbol filter extracted from INFO payload (example `TP53`).
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          schema:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        "200":
+          description: Paginated variant results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VariantQueryResponse"
+        "400":
+          description: Invalid query filters
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "500":
+          description: Query execution failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
+        "503":
+          description: Variant query service not configured
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetails"
 components:
   schemas:
     VersionInfo:
@@ -391,6 +465,78 @@ components:
           type: integer
           format: int64
           description: One-based record index for the failure, when available.
+    VariantRecord:
+      type: object
+      required:
+        - chromosome
+        - position
+        - ref
+        - alt
+        - filter
+        - info
+      properties:
+        chromosome:
+          type: string
+        position:
+          type: integer
+          format: int64
+        ref:
+          type: string
+        alt:
+          type: string
+        qual:
+          type: number
+          format: double
+          nullable: true
+        filter:
+          type: string
+        info:
+          type: string
+        gene:
+          type: string
+    VariantQueryFilters:
+      type: object
+      properties:
+        chromosome:
+          type: string
+        position_min:
+          type: integer
+          format: int64
+        position_max:
+          type: integer
+          format: int64
+        gene:
+          type: string
+    VariantQueryResponse:
+      type: object
+      required:
+        - data
+        - page
+        - page_size
+        - total
+        - has_next
+        - filters
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/VariantRecord"
+        page:
+          type: integer
+          format: int32
+        page_size:
+          type: integer
+          format: int32
+        total:
+          type: integer
+          format: int64
+        has_next:
+          type: boolean
+        latency_ms:
+          type: integer
+          format: int64
+        filters:
+          $ref: "#/components/schemas/VariantQueryFilters"
     MultipartInitRequest:
       type: object
       additionalProperties: false

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -332,6 +332,7 @@ paths:
           in: query
           schema:
             type: string
+            pattern: "^[A-Za-z0-9._-]+$"
           description: Exact chromosome value (example `chr1`).
         - name: position_min
           in: query
@@ -339,6 +340,7 @@ paths:
             type: integer
             format: int64
             minimum: 0
+            maximum: 4294967295
           description: Inclusive lower bound for position.
         - name: position_max
           in: query
@@ -346,11 +348,13 @@ paths:
             type: integer
             format: int64
             minimum: 0
+            maximum: 4294967295
           description: Inclusive upper bound for position.
         - name: gene
           in: query
           schema:
             type: string
+            pattern: "^[A-Za-z0-9._-]+$"
           description: Gene symbol filter extracted from INFO payload (example `TP53`).
         - name: page
           in: query
@@ -515,6 +519,7 @@ components:
         - page_size
         - total
         - has_next
+        - latency_ms
         - filters
       properties:
         data:

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -524,6 +524,7 @@ components:
       properties:
         data:
           type: array
+          maxItems: 200
           items:
             $ref: "#/components/schemas/VariantRecord"
         page:

--- a/docs/api/variant-query.md
+++ b/docs/api/variant-query.md
@@ -1,0 +1,36 @@
+# Variant query API (Issue 14)
+
+`GET /v1/variants` queries ClickHouse variant rows with safe filters and pagination.
+
+## Query parameters
+
+- `chromosome` (optional): exact chromosome match (for example `chr1`)
+- `position_min` (optional): inclusive lower bound
+- `position_max` (optional): inclusive upper bound
+- `gene` (optional): gene symbol filter (`GENE=` token in INFO)
+- `page` (optional, default `1`, min `1`)
+- `page_size` (optional, default `50`, min `1`, max `200`)
+
+## Validation rules
+
+- `chromosome` and `gene` must match `^[A-Za-z0-9._-]+$`.
+- `position_min`/`position_max` must be unsigned 32-bit integers.
+- if both position bounds are provided, `position_min <= position_max`.
+- invalid inputs return RFC7807 `400 application/problem+json`.
+
+## Response shape
+
+`200 application/json` returns:
+
+- `data`: list of variants (`chromosome`, `position`, `ref`, `alt`, `qual`, `filter`, `info`, `gene`)
+- pagination metadata: `page`, `page_size`, `total`, `has_next`
+- observability fields: `latency_ms`, applied `filters`
+
+## Local verification
+
+From `backend/`:
+
+```bash
+go test ./internal/api/variantquery -count=1
+CLICKHOUSE_DSN='clickhouse://default:senju_dev_password@localhost:9000/senju' go test ./internal/variant/clickhouse -run 'TestQueryRepository_IntegrationFiltersAndPagination|TestQueryRepository_P95Under500ms' -count=1
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -54,6 +54,10 @@ Use the same environment variables as in `.env` (`POSTGRES_*` or `POSTGRES_DSN`)
 
 After migrations and with Postgres reachable, the API can register FASTQ ingestion jobs. See [docs/api/fastq-upload.md](./api/fastq-upload.md).
 
+## Variant query API
+
+Variant retrieval with filters/pagination is documented in [docs/api/variant-query.md](./api/variant-query.md).
+
 ## Queue semantics (NATS + retries)
 
 Queue retry/dead-letter behavior and env configuration are documented in [docs/pipeline/nats-queue.md](./pipeline/nats-queue.md).


### PR DESCRIPTION
Closes #14

## Summary
- Add `GET /v1/variants` API with validated filters (`chromosome`, `position_min`, `position_max`, `gene`) and pagination (`page`, `page_size`).
- Add ClickHouse query repository (`internal/variant/clickhouse/query.go`) with parameterized filtering, deterministic ordering, and paginated response metadata.
- Wire variant query service into API startup using derived/explicit `CLICKHOUSE_DSN`; update OpenAPI and developer docs.

## Test evidence
- `cd backend && go test ./internal/api/variantquery -count=1`
- `cd backend && CLICKHOUSE_DSN='clickhouse://default:senju_dev_password@localhost:9000/senju' go test ./internal/variant/clickhouse -run TestQueryRepository_IntegrationFiltersAndPagination -count=1`
- `cd backend && CLICKHOUSE_DSN='clickhouse://default:senju_dev_password@localhost:9000/senju' go test ./internal/variant/clickhouse -run TestQueryRepository_P95Under500ms -count=1`
- `cd backend && golangci-lint run ./...`
- `cd backend && go test ./...`
- `cd backend && go test -race ./...`

### Non-functional evidence (latency)
- `TestQueryRepository_P95Under500ms` passed on benchmark dataset seeded during test execution (`5000` rows, `200` measured queries, p95 asserted `< 500ms`).

## Failure cases validated
- Invalid/unsafe query parameters are rejected with `400` RFC7807 validation errors.
- Position range validation rejects `position_min > position_max`.
- Service-unavailable path returns `503` when ClickHouse query service is not configured.
- Repository/service query failures return `500` with stable error contract.

## Rollback notes
- Revert this PR to remove the variant query endpoint and ClickHouse query wiring.
- Optional config cleanup: remove `CLICKHOUSE_DSN` from local `.env` if no longer needed.
- Data rollback is not required (read-path feature only; no schema mutation in this issue).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /v1/variants API endpoint with filtering (chromosome, position range, gene) and page-based pagination
  * Added optional CLICKHOUSE_DSN environment variable to explicitly configure ClickHouse connection

* **Documentation**
  * Added Variant Query API docs and README link describing parameters, validation, responses, and local verification

* **Tests**
  * Added unit and integration tests covering handler behavior and ClickHouse query repository
<!-- end of auto-generated comment: release notes by coderabbit.ai -->