### PR TITLE
feat(reliability): checkpoint/restart controls for alignment stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 - Contribution standards: `docs/contributing.md`
 - Security baseline (JWT/RBAC, secret rotation, CI scanning): `docs/security.md`
+- Reliability controls (checkpoint/restart, recovery assumptions): `docs/reliability.md`
 - PR template: `.github/pull_request_template.md`
 - Issue templates: `.github/ISSUE_TEMPLATE/`
 - Code ownership: `CODEOWNERS`

--- a/backend/internal/pipeline/alignment/worker.go
+++ b/backend/internal/pipeline/alignment/worker.go
@@ -103,6 +103,11 @@ type payload struct {
 	MemoryLimitMB  int    `json:"memory_limit_mb,omitempty"`
 }
 
+type checkpoint struct {
+	Version int    `json:"version"`
+	SAMPath string `json:"sam_path"`
+}
+
 // Handle executes alignment for one queued job message.
 func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
 	jobID, err := uuid.Parse(msg.JobID)
@@ -191,19 +196,42 @@ func (w *Worker) Handle(ctx context.Context, msg queue.Message) error {
 }
 
 func (w *Worker) runPipeline(ctx context.Context, p payload, threads, memMB int) (int, error) {
-	tmpSAMPath := filepath.Join(os.TempDir(), "senju-align-"+uuid.NewString()+".sam")
-	defer func() { _ = os.Remove(tmpSAMPath) }()
-
-	bwaArgs := []string{
-		"mem",
-		"-t", fmt.Sprintf("%d", threads),
-		"-o", tmpSAMPath,
-		p.ReferencePath,
-		p.Read1Path,
-		p.Read2Path,
+	cpPath := checkpointPathForBAM(p.OutputBAMPath)
+	cp, err := readCheckpoint(cpPath)
+	if err != nil {
+		return -1, fmt.Errorf("alignment worker: read checkpoint: %w", err)
 	}
-	if code, err := w.runner.Run(ctx, "bwa", bwaArgs...); err != nil {
-		return code, err
+	tmpSAMPath := cp.SAMPath
+	if tmpSAMPath == "" {
+		tmpSAMPath = filepath.Join(os.TempDir(), "senju-align-"+uuid.NewString()+".sam")
+	}
+	completed := false
+	defer func() {
+		if !completed {
+			return
+		}
+		_ = os.Remove(tmpSAMPath)
+		_ = os.Remove(cpPath)
+	}()
+
+	if cp.SAMPath == "" {
+		bwaArgs := []string{
+			"mem",
+			"-t", fmt.Sprintf("%d", threads),
+			"-o", tmpSAMPath,
+			p.ReferencePath,
+			p.Read1Path,
+			p.Read2Path,
+		}
+		if code, err := w.runner.Run(ctx, "bwa", bwaArgs...); err != nil {
+			return code, err
+		}
+		if err := writeCheckpoint(cpPath, checkpoint{
+			Version: 1,
+			SAMPath: tmpSAMPath,
+		}); err != nil {
+			return -1, fmt.Errorf("alignment worker: write checkpoint: %w", err)
+		}
 	}
 
 	samtoolsArgs := []string{
@@ -214,7 +242,47 @@ func (w *Worker) runPipeline(ctx context.Context, p payload, threads, memMB int)
 		tmpSAMPath,
 	}
 	code, err := w.runner.Run(ctx, "samtools", samtoolsArgs...)
+	if err == nil {
+		completed = true
+	}
 	return code, err
+}
+
+func checkpointPathForBAM(outputBAMPath string) string {
+	return outputBAMPath + ".checkpoint.json"
+}
+
+func readCheckpoint(path string) (checkpoint, error) {
+	// #nosec G304 -- path is derived from validated output_bam_path worker payload/config.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return checkpoint{}, nil
+		}
+		return checkpoint{}, err
+	}
+	var cp checkpoint
+	if err := json.Unmarshal(raw, &cp); err != nil {
+		return checkpoint{}, err
+	}
+	if cp.Version != 1 || cp.SAMPath == "" {
+		return checkpoint{}, errors.New("invalid checkpoint")
+	}
+	if _, err := os.Stat(cp.SAMPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return checkpoint{}, nil
+		}
+		return checkpoint{}, err
+	}
+	return cp, nil
+}
+
+func writeCheckpoint(path string, cp checkpoint) error {
+	body, err := json.Marshal(cp)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, body, 0o600)
 }
 
 func (w *Worker) persistTerminalFailure(ctx context.Context, jobID uuid.UUID, exitCode int, p payload, threads, memMB int, failure error) error {

--- a/backend/internal/pipeline/alignment/worker_test.go
+++ b/backend/internal/pipeline/alignment/worker_test.go
@@ -428,3 +428,91 @@ func TestWorkerHandle_FailureCases_TableDriven(t *testing.T) {
 		})
 	}
 }
+
+func TestWorkerHandle_CheckpointResumeAfterInterruption(t *testing.T) {
+	t.Parallel()
+	repo := newRecordingRepo()
+	created, err := repo.Create(context.Background(), job.CreateParams{Status: job.StatusPending, Stage: "queued"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	bamPath := filepath.Join(tmpDir, "out.bam")
+	cpPath := checkpointPathForBAM(bamPath)
+
+	var calls []string
+	firstRunner := &fakeRunner{
+		run: func(_ context.Context, name string, args ...string) (int, error) {
+			calls = append(calls, name)
+			switch name {
+			case "bwa":
+				samOut := args[4] // mem -t N -o <sam> ...
+				if err := os.WriteFile(samOut, []byte("sam-content"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return 0, nil
+			case "samtools":
+				return -1, context.DeadlineExceeded
+			default:
+				return -1, errors.New("unexpected command")
+			}
+		},
+	}
+	w1, err := NewWorker(repo, firstRunner, zerolog.Nop(), Config{DefaultTimeout: time.Second}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"reference_path":"/ref.fa","read1_path":"/r1","read2_path":"/r2","output_bam_path":"` + bamPath + `"}`
+	if err := w1.Handle(context.Background(), queue.Message{
+		JobID:   created.ID.String(),
+		Payload: json.RawMessage(payload),
+	}); err != nil {
+		t.Fatalf("expected nil after terminal persistence, got %v", err)
+	}
+	if _, err := os.Stat(cpPath); err != nil {
+		t.Fatalf("expected checkpoint file, got %v", err)
+	}
+
+	secondRunner := &fakeRunner{
+		run: func(_ context.Context, name string, _ ...string) (int, error) {
+			calls = append(calls, name)
+			if name == "samtools" {
+				if err := os.WriteFile(bamPath, []byte("resumed-bam"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return 0, nil
+			}
+			return -1, errors.New("bwa should be skipped on resume")
+		},
+	}
+	w2, err := NewWorker(repo, secondRunner, zerolog.Nop(), Config{DefaultTimeout: time.Second}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Handle(context.Background(), queue.Message{
+		JobID:   created.ID.String(),
+		Payload: json.RawMessage(payload),
+	}); err != nil {
+		t.Fatalf("unexpected resume error: %v", err)
+	}
+
+	updated, err := repo.GetByID(context.Background(), created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != job.StatusSucceeded || updated.Stage != StageAlignmentSucceeded {
+		t.Fatalf("job %+v", updated)
+	}
+	if !bytes.Contains(updated.OutputRef, []byte(`"checksum_sha256"`)) {
+		t.Fatalf("output_ref %s", updated.OutputRef)
+	}
+	if _, err := os.Stat(cpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("checkpoint should be removed, stat err=%v", err)
+	}
+
+	// First run executes bwa+samtools, second run resumes with samtools only.
+	got := strings.Join(calls, ",")
+	if got != "bwa,samtools,samtools" {
+		t.Fatalf("unexpected call order %q", got)
+	}
+}

--- a/docs/pipeline/nats-queue.md
+++ b/docs/pipeline/nats-queue.md
@@ -85,3 +85,13 @@ Labels are consistent across stages:
 - `stage`
 - `outcome` (`success`/`failure`)
 - `error_class` (empty for success; failure classification when available)
+
+## Reliability controls: checkpoint/restart (Issue #18)
+
+Alignment worker now supports checkpoint-based restart semantics:
+
+- After successful `bwa mem`, the worker writes a checkpoint file alongside the target BAM path (`<output_bam_path>.checkpoint.json`) containing the intermediate SAM file path.
+- If the worker is interrupted before `samtools sort` completes, a retry resumes from checkpoint and **skips `bwa mem`** instead of restarting from scratch.
+- On successful completion, intermediate SAM and checkpoint files are removed.
+
+This improves recovery behavior during worker restarts/crashes while avoiding partial-output corruption.

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -1,0 +1,32 @@
+# Reliability controls
+
+Issue: [#18](https://github.com/AminN77/senju/issues/18)
+
+## Checkpoint/restart baseline
+
+Current checkpoint/restart support is implemented for the alignment stage (`bwa` + `samtools`):
+
+- checkpoint file: `<output_bam_path>.checkpoint.json`
+- checkpoint is persisted only after `bwa mem` succeeds
+- retries can resume from checkpoint and run `samtools sort` without re-running `bwa`
+
+## Recovery objective assumptions (RTO)
+
+For alignment stage interruptions where checkpoint exists:
+
+- restart path skips expensive re-alignment and resumes sorting/output write
+- expected RTO is bounded by:
+  - queue redelivery delay (`QUEUE_BACKOFF_BASE`, retries)
+  - worker startup latency
+  - remaining `samtools sort` runtime
+
+Without checkpoint (interruption before checkpoint persistence), the stage restarts from `bwa`.
+
+## Chaos test evidence
+
+`backend/internal/pipeline/alignment/worker_test.go` includes a chaos-style recovery test:
+
+- first run simulates interruption after `bwa` and before successful `samtools`
+- checkpoint is verified present
+- second run resumes, skips `bwa`, runs `samtools`, and reaches `alignment_succeeded`
+- output metadata includes checksum and checkpoint cleanup is verified

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -70,6 +70,10 @@ JWT auth/RBAC, secret handling, and rotation guidance are documented in [docs/se
 
 Queue retry/dead-letter behavior and env configuration are documented in [docs/pipeline/nats-queue.md](./pipeline/nats-queue.md).
 
+## Reliability controls
+
+Checkpoint/restart behavior and recovery assumptions are documented in [docs/reliability.md](./reliability.md).
+
 ## Observability baseline
 
 Monitoring/logging stack setup (Prometheus, Loki, Grafana) is documented in [docs/observability.md](./observability.md).


### PR DESCRIPTION
## Summary
- Add checkpoint/restart reliability controls to the alignment worker so interrupted runs can resume from a persisted post-BWA checkpoint instead of full stage restart.
- Persist and validate `<output_bam_path>.checkpoint.json` after successful `bwa mem`, then resume directly to `samtools sort` when retried.
- Clean up checkpoint and intermediate SAM only after successful terminal completion to preserve restart safety.
- Add chaos-style recovery test that simulates interruption mid-run and verifies resume behavior, successful completion, checksum output, and checkpoint cleanup.
- Document recovery assumptions (RTO) and checkpoint behavior.

Closes #18.

## Test evidence
- `cd backend && go test ./internal/pipeline/alignment -count=1`
- `cd backend && go test ./... -count=1`
- `cd backend && golangci-lint run ./...`
- `cd backend && go test -race ./...`

Result: all passed.

## Failure cases validated
- Interruption after `bwa` and before successful `samtools` leaves checkpoint persisted.
- Retry resumes from checkpoint (skips `bwa`), completes `samtools`, persists succeeded status/output metadata, and removes checkpoint.

## Rollback notes
- Revert commit `b40f064` to remove checkpoint/restart logic and reliability docs.
- No schema migrations were introduced; rollback is code-only.
- Existing queue retry/dead-letter behavior remains unchanged.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Alignment pipeline now supports checkpoint and resume functionality: if processing is interrupted, retries continue from the checkpoint rather than restarting from scratch.
  * Temporary intermediate files are automatically cleaned up upon successful completion.

* **Documentation**
  * Added comprehensive reliability controls documentation detailing checkpoint/restart behavior and recovery assumptions for the alignment stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->