### PR TITLE
feat(perf): performance qualification and regression gates (#19)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,3 +49,8 @@ jobs:
 
       - name: Go vet
         run: go vet ./...
+
+      - name: Performance regression gate
+        run: |
+          go test -run '^$' -bench 'BenchmarkMultipartInit_Throughput|BenchmarkAlignmentHandle_Throughput|BenchmarkGetVariants_Latency' -benchmem -count=1 ./internal/api/objectupload ./internal/pipeline/alignment ./internal/api/variantquery > /tmp/bench.txt
+          go run ./cmd/perfcheck

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - Contribution standards: `docs/contributing.md`
 - Security baseline (JWT/RBAC, secret rotation, CI scanning): `docs/security.md`
 - Reliability controls (checkpoint/restart, recovery assumptions): `docs/reliability.md`
+- Performance qualification and regression gates: `docs/performance.md`
 - PR template: `.github/pull_request_template.md`
 - Issue templates: `.github/ISSUE_TEMPLATE/`
 - Code ownership: `CODEOWNERS`

--- a/backend/cmd/perfcheck/main.go
+++ b/backend/cmd/perfcheck/main.go
@@ -1,0 +1,124 @@
+// Command perfcheck compares benchmark output against repository baselines.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type baseline struct {
+	Policy struct {
+		WarnRegressionPct float64 `json:"warn_regression_pct"`
+		FailRegressionPct float64 `json:"fail_regression_pct"`
+	} `json:"policy"`
+	Benchmarks map[string]struct {
+		TargetNSOp float64 `json:"target_ns_op"`
+	} `json:"benchmarks"`
+}
+
+var benchLine = regexp.MustCompile(`^(Benchmark[^\s]+)\s+\d+\s+([0-9.]+)\s+ns/op`)
+
+func main() {
+	const (
+		baselinePath = "./perf/baseline.json"
+		resultsPath  = "/tmp/bench.txt"
+	)
+	if len(os.Args) != 1 {
+		fail("usage: go run ./cmd/perfcheck")
+	}
+	base, err := loadBaseline(baselinePath)
+	if err != nil {
+		fail(err.Error())
+	}
+	results, err := loadBenchResults(resultsPath)
+	if err != nil {
+		fail(err.Error())
+	}
+	hardFail := false
+	for name, cfg := range base.Benchmarks {
+		got, ok := results[name]
+		if !ok {
+			hardFail = true
+			fmt.Printf("FAIL: benchmark %s not found in results\n", name)
+			continue
+		}
+		if cfg.TargetNSOp <= 0 {
+			fmt.Printf("WARN: benchmark %s has non-positive target\n", name)
+			continue
+		}
+		regression := ((got - cfg.TargetNSOp) / cfg.TargetNSOp) * 100
+		if regression > base.Policy.FailRegressionPct {
+			hardFail = true
+			fmt.Printf("FAIL: %s regressed %.2f%% (target %.2f ns/op, got %.2f ns/op)\n", name, regression, cfg.TargetNSOp, got)
+			continue
+		}
+		if regression > base.Policy.WarnRegressionPct {
+			fmt.Printf("WARN: %s regressed %.2f%% (target %.2f ns/op, got %.2f ns/op)\n", name, regression, cfg.TargetNSOp, got)
+			continue
+		}
+		fmt.Printf("PASS: %s %.2f ns/op (target %.2f)\n", name, got, cfg.TargetNSOp)
+	}
+	if hardFail {
+		os.Exit(1)
+	}
+}
+
+func loadBaseline(path string) (baseline, error) {
+	// #nosec G304 -- path is provided by trusted CI/local command invocation.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return baseline{}, err
+	}
+	var b baseline
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return baseline{}, err
+	}
+	if len(b.Benchmarks) == 0 {
+		return baseline{}, errors.New("baseline has no benchmarks")
+	}
+	return b, nil
+}
+
+func loadBenchResults(path string) (map[string]float64, error) {
+	// #nosec G304 -- path is provided by trusted CI/local command invocation.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	out := map[string]float64{}
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		m := benchLine.FindStringSubmatch(line)
+		if len(m) != 3 {
+			continue
+		}
+		v, err := strconv.ParseFloat(m[2], 64)
+		if err != nil {
+			return nil, err
+		}
+		name := m[1]
+		if idx := strings.LastIndex(name, "-"); idx > 0 {
+			if _, err := strconv.Atoi(name[idx+1:]); err == nil {
+				name = name[:idx]
+			}
+		}
+		out[name] = v
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func fail(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	os.Exit(2)
+}

--- a/backend/internal/api/objectupload/handler_test.go
+++ b/backend/internal/api/objectupload/handler_test.go
@@ -175,6 +175,29 @@ func TestSanitizeFilenameHint(t *testing.T) {
 
 func ptr(s string) *string { return &s }
 
+func BenchmarkMultipartInit_Throughput(b *testing.B) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	Register(r.Group("/v1/objects"), &fakeStore{
+		createFn: func(_ context.Context, objectKey, _ string) (*objectstore.MultipartCreateResult, error) {
+			return &objectstore.MultipartCreateResult{
+				Bucket: "b", ObjectKey: objectKey, UploadID: "u", PartSizeBytes: objectstore.DefaultPartSizeBytes,
+			}, nil
+		},
+	}, zerolog.Nop())
+	body := `{"content_type":"application/octet-stream"}`
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/v1/objects/multipart", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			b.Fatalf("status %d", w.Code)
+		}
+	}
+}
+
 func TestDecodeJSON_TrailingRejected(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/api/variantquery/handler_test.go
+++ b/backend/internal/api/variantquery/handler_test.go
@@ -139,3 +139,26 @@ func TestGetVariants_503_NoService(t *testing.T) {
 		t.Fatalf("body %s", w.Body.String())
 	}
 }
+
+func BenchmarkGetVariants_Latency(b *testing.B) {
+	gin.SetMode(gin.ReleaseMode)
+	svc := &fakeService{
+		res: QueryResult{
+			Rows: []QueryRow{
+				{Chromosome: "chr1", Position: 123, Ref: "A", Alt: "T", Filter: "PASS", Info: "GENE=TP53", Gene: "TP53"},
+			},
+			Total: 1, Page: 1, PageSize: 50,
+		},
+	}
+	r := gin.New()
+	Register(r.Group("/v1"), svc)
+	req := httptest.NewRequest(http.MethodGet, "/v1/variants?page=1&page_size=50", nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req.Clone(context.Background()))
+		if w.Code != http.StatusOK {
+			b.Fatalf("status %d", w.Code)
+		}
+	}
+}

--- a/backend/internal/pipeline/alignment/worker_test.go
+++ b/backend/internal/pipeline/alignment/worker_test.go
@@ -516,3 +516,45 @@ func TestWorkerHandle_CheckpointResumeAfterInterruption(t *testing.T) {
 		t.Fatalf("unexpected call order %q", got)
 	}
 }
+
+func BenchmarkAlignmentHandle_Throughput(b *testing.B) {
+	repo := newRecordingRepo()
+	runner := &fakeRunner{
+		run: func(_ context.Context, name string, args ...string) (int, error) {
+			if name == "samtools" {
+				out := args[6] // sort -@ N -m XM -o <bam> <sam>
+				if err := os.WriteFile(out, []byte("bench-bam"), 0o644); err != nil {
+					return -1, err
+				}
+				return 0, nil
+			}
+			if name == "bwa" {
+				samOut := args[4]
+				if err := os.WriteFile(samOut, []byte("bench-sam"), 0o644); err != nil {
+					return -1, err
+				}
+				return 0, nil
+			}
+			return -1, errors.New("unexpected command")
+		},
+	}
+	w, err := NewWorker(repo, runner, zerolog.Nop(), Config{DefaultTimeout: time.Second}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j, err := repo.Create(context.Background(), job.CreateParams{Status: job.StatusPending, Stage: "queued"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		bamPath := filepath.Join(b.TempDir(), uuid.NewString()+".bam")
+		payload := `{"reference_path":"/ref.fa","read1_path":"/r1","read2_path":"/r2","output_bam_path":"` + bamPath + `"}`
+		if err := w.Handle(context.Background(), queue.Message{
+			JobID:   j.ID.String(),
+			Payload: json.RawMessage(payload),
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/backend/perf/baseline.json
+++ b/backend/perf/baseline.json
@@ -1,0 +1,17 @@
+{
+  "policy": {
+    "warn_regression_pct": 10.0,
+    "fail_regression_pct": 20.0
+  },
+  "benchmarks": {
+    "BenchmarkMultipartInit_Throughput": {
+      "target_ns_op": 2500.0
+    },
+    "BenchmarkAlignmentHandle_Throughput": {
+      "target_ns_op": 320000.0
+    },
+    "BenchmarkGetVariants_Latency": {
+      "target_ns_op": 1200.0
+    }
+  }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,46 @@
+# Performance qualification and regression gates
+
+Issue: [#19](https://github.com/AminN77/senju/issues/19)
+
+## Benchmark coverage
+
+The repository includes targeted benchmarks for core performance paths:
+
+- Upload throughput:
+  - `BenchmarkMultipartInit_Throughput` (`internal/api/objectupload`)
+- Pipeline throughput:
+  - `BenchmarkAlignmentHandle_Throughput` (`internal/pipeline/alignment`)
+- Query latency:
+  - `BenchmarkGetVariants_Latency` (`internal/api/variantquery`)
+
+## Baseline targets and thresholds
+
+Stored in repository:
+
+- baseline file: `backend/perf/baseline.json`
+- comparator tool: `backend/cmd/perfcheck`
+
+`baseline.json` defines:
+
+- per-benchmark `target_ns_op`
+- warn threshold (`warn_regression_pct`)
+- fail threshold (`fail_regression_pct`)
+
+## CI regression policy
+
+`Backend CI` runs a performance gate step:
+
+1. execute benchmark subset
+2. compare measured `ns/op` against baseline targets
+3. emit:
+   - `PASS` when within warn threshold
+   - `WARN` when regression > warn threshold
+   - `FAIL` when regression > fail threshold (CI failure)
+
+## Local verification
+
+```bash
+cd backend
+go test -run '^$' -bench 'BenchmarkMultipartInit_Throughput|BenchmarkAlignmentHandle_Throughput|BenchmarkGetVariants_Latency' -benchmem -count=1 ./internal/api/objectupload ./internal/pipeline/alignment ./internal/api/variantquery > /tmp/bench.txt
+go run ./cmd/perfcheck
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,6 +74,10 @@ Queue retry/dead-letter behavior and env configuration are documented in [docs/p
 
 Checkpoint/restart behavior and recovery assumptions are documented in [docs/reliability.md](./reliability.md).
 
+## Performance qualification
+
+Benchmark suite and regression gate policy are documented in [docs/performance.md](./performance.md).
+
 ## Observability baseline
 
 Monitoring/logging stack setup (Prometheus, Loki, Grafana) is documented in [docs/observability.md](./observability.md).


### PR DESCRIPTION
## Summary
- add a benchmark qualification suite covering upload throughput, alignment throughput, and variant query latency
- add repository-managed performance baselines and a `perfcheck` comparator with warn/fail regression policy
- enforce performance regression checks in Backend CI and document local/CI usage in `docs/performance.md`

## Test evidence
- `cd backend && go test -run '^$' -bench 'BenchmarkMultipartInit_Throughput|BenchmarkAlignmentHandle_Throughput|BenchmarkGetVariants_Latency' -benchmem -count=1 ./internal/api/objectupload ./internal/pipeline/alignment ./internal/api/variantquery > /tmp/bench.txt`
- `cd backend && go run ./cmd/perfcheck`
  - PASS: `BenchmarkMultipartInit_Throughput 2346.00 ns/op (target 2500.00)`
  - PASS: `BenchmarkAlignmentHandle_Throughput 315246.00 ns/op (target 320000.00)`
  - PASS: `BenchmarkGetVariants_Latency 1127.00 ns/op (target 1200.00)`
- `cd backend && go test ./... -count=1`
- `cd backend && golangci-lint run ./...`
- `cd backend && go test -race ./...`

## Failure cases validated
- benchmark gate now fails when any expected benchmark result is missing from `/tmp/bench.txt`
- comparator warns on regressions above warn threshold and fails CI above fail threshold

## Rollback notes
- revert commit `47a117c` to remove the performance gate, baseline policy, and benchmark additions
- no schema/data migrations are introduced; rollback is code-only and low risk

## Links
- Closes #19

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for multipart upload, alignment pipeline, and query operations
  * Introduced performance regression detection gate in CI/CD workflow

* **Documentation**
  * Added performance qualification guide with regression thresholds and verification instructions
  * Updated README with reference to performance documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->