### PR TITLE
feat(frontend): add typography scale and font loading strategy (issue #53)

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -80,6 +80,16 @@ pnpm codegen:check
 - Runtime API usage should go through `src/lib/api/client.ts` so auth header injection, request IDs, and error normalization stay consistent across call sites.
 - Form/input validation should use schemas in `src/lib/api/schemas.ts` (or colocated schemas) that mirror generated contract types.
 
+## Typography and font loading
+
+- UI sans font: Inter variable via `next/font/google`.
+- Mono font: JetBrains Mono variable via `next/font/google`.
+- Include `subsets: ["latin", "latin-ext"]` and `display: "swap"` for both font families.
+- Fonts are self-hosted through Next.js font optimization and must not be fetched from Google CDN at runtime.
+- Keep font CSS variable wiring aligned with tokens:
+  - `--font-inter` -> `--font-sans`
+  - `--font-jetbrains-mono` -> `--font-mono`
+
 ## Auth/session baseline
 
 - Session state is centralized in `src/lib/auth/session-provider.tsx`.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10,3 +10,73 @@ body {
   color: var(--color-text-primary);
   font-family: var(--font-sans), sans-serif;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+h1 {
+  font-size: var(--text-heading-xl);
+  line-height: var(--leading-heading-xl);
+  letter-spacing: var(--tracking-heading);
+}
+
+h2 {
+  font-size: var(--text-heading-lg);
+  line-height: var(--leading-heading-lg);
+  letter-spacing: var(--tracking-heading);
+}
+
+h3 {
+  font-size: var(--text-heading-md);
+  line-height: var(--leading-heading-md);
+}
+
+h4,
+h5,
+h6 {
+  font-size: var(--text-heading-sm);
+  line-height: var(--leading-heading-sm);
+}
+
+p {
+  margin: 0;
+  font-size: var(--text-body-md);
+  line-height: var(--leading-body);
+  letter-spacing: var(--tracking-body);
+  color: var(--color-text-secondary);
+}
+
+ul,
+ol {
+  margin: 0;
+  padding-inline-start: var(--space-6);
+}
+
+li {
+  font-size: var(--text-body-md);
+  line-height: var(--leading-body);
+  color: var(--color-text-secondary);
+}
+
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-mono), monospace;
+}
+
+code,
+kbd,
+samp {
+  font-size: var(--text-code-md);
+  line-height: var(--leading-code-md);
+  letter-spacing: var(--tracking-code);
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,18 +1,20 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono } from "next/font/google";
 
 import { SessionProvider } from "@/lib/auth/session-provider";
 
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+const jetBrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -29,7 +31,7 @@ export default function RootLayout({
     <html
       lang="en"
       data-theme="dark"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${inter.variable} ${jetBrainsMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <SessionProvider>{children}</SessionProvider>

--- a/frontend/src/stories/typography-scale.stories.mdx
+++ b/frontend/src/stories/typography-scale.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta } from "@storybook/blocks";
+
+<Meta title="Foundations/Typography Scale" />
+
+# Typography Scale
+
+Source of truth: `docs/frontend/design-system.md` §2 and `src/styles/tokens.css`.
+
+Fonts are loaded with `next/font/google` as variable fonts:
+
+- Sans UI font: Inter (`latin`, `latin-ext`, `display: swap`)
+- Mono font: JetBrains Mono (`latin`, `latin-ext`, `display: swap`)
+
+## Display
+
+<div className="space-y-3 rounded-md border border-border-default bg-surface-raised p-4">
+  <p className="text-display-lg text-text-primary">
+    Display LG - 48/56 - The quick brown fox jumps over the lazy dog.
+  </p>
+  <p className="text-display-md text-text-primary">
+    Display MD - 36/44 - The quick brown fox jumps over the lazy dog.
+  </p>
+</div>
+
+## Heading
+
+<div className="space-y-3 rounded-md border border-border-default bg-surface-raised p-4">
+  <p className="text-heading-xl text-text-primary">Heading XL - 28/36 - Section title example</p>
+  <p className="text-heading-lg text-text-primary">Heading LG - 22/30 - Section title example</p>
+  <p className="text-heading-md text-text-primary">Heading MD - 18/26 - Section title example</p>
+  <p className="text-heading-sm text-text-primary">Heading SM - 16/24 - Section title example</p>
+</div>
+
+## Body
+
+<div className="space-y-3 rounded-md border border-border-default bg-surface-raised p-4">
+  <p className="text-body-lg text-text-secondary">
+    Body LG - 16/26 - Default marketing body copy for readable long-form paragraphs.
+  </p>
+  <p className="text-body-md text-text-secondary">
+    Body MD - 14/22 - Default application body copy for forms, tables, and settings.
+  </p>
+  <p className="text-body-sm text-text-secondary">
+    Body SM - 13/20 - Secondary metadata and support copy.
+  </p>
+  <p className="text-caption text-text-muted">
+    Caption - 12/18 - Labels, badges, and compact contextual hints.
+  </p>
+</div>
+
+## Code
+
+<div className="space-y-3 rounded-md border border-border-default bg-surface-raised p-4">
+  <p className="font-mono text-code-md text-text-primary">Code MD - run_id=senju-abc123</p>
+  <p className="font-mono text-code-sm text-text-primary">Code SM - chr7:140453136 A&gt;T</p>
+</div>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -135,8 +135,8 @@
   --shadow-overlay: 0 24px 48px -16px oklch(20% 0.014 250 / 0.26);
 
   /* Typography tokens */
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-inter);
+  --font-mono: var(--font-jetbrains-mono);
   --text-body-md: 0.875rem;
   --text-display-lg: 3rem;
   --text-display-md: 2.25rem;

--- a/frontend/src/styles/tokens.test.ts
+++ b/frontend/src/styles/tokens.test.ts
@@ -28,20 +28,59 @@ describe("theme tokens", () => {
 
     setTheme("light");
     const lightStyles = getComputedStyle(document.documentElement);
-    expect(resolveValue(lightStyles.getPropertyValue("--color-surface-raised")).replace(/\s+/g, "")).toBe(
-      "oklch(100%00)"
-    );
-    expect(resolveValue(lightStyles.getPropertyValue("--color-text-primary")).replace(/\s+/g, "")).toBe(
-      "oklch(20%0.014250)"
-    );
+    expect(
+      resolveValue(lightStyles.getPropertyValue("--color-surface-raised")).replace(/\s+/g, "")
+    ).toBe("oklch(100%00)");
+    expect(
+      resolveValue(lightStyles.getPropertyValue("--color-text-primary")).replace(/\s+/g, "")
+    ).toBe("oklch(20%0.014250)");
 
     setTheme("dark");
     const darkStyles = getComputedStyle(document.documentElement);
-    expect(resolveValue(darkStyles.getPropertyValue("--color-surface-raised")).replace(/\s+/g, "")).toBe(
-      "oklch(20%0.014250)"
-    );
-    expect(resolveValue(darkStyles.getPropertyValue("--color-text-primary")).replace(/\s+/g, "")).toBe(
-      "oklch(98%0.003250)"
-    );
+    expect(
+      resolveValue(darkStyles.getPropertyValue("--color-surface-raised")).replace(/\s+/g, "")
+    ).toBe("oklch(20%0.014250)");
+    expect(
+      resolveValue(darkStyles.getPropertyValue("--color-text-primary")).replace(/\s+/g, "")
+    ).toBe("oklch(98%0.003250)");
+  });
+
+  it("defines typography scale tokens from the design spec", () => {
+    const expectedTypographyTokens: Array<[token: string, value: string]> = [
+      ["text-display-lg", "3rem"],
+      ["text-display-md", "2.25rem"],
+      ["text-heading-xl", "1.75rem"],
+      ["text-heading-lg", "1.375rem"],
+      ["text-heading-md", "1.125rem"],
+      ["text-heading-sm", "1rem"],
+      ["text-body-lg", "1rem"],
+      ["text-body-md", "0.875rem"],
+      ["text-body-sm", "0.8125rem"],
+      ["text-caption", "0.75rem"],
+      ["text-code-md", "0.8125rem"],
+      ["text-code-sm", "0.75rem"],
+      ["leading-display-lg", "3.5rem"],
+      ["leading-display-md", "2.75rem"],
+      ["leading-heading-xl", "2.25rem"],
+      ["leading-heading-lg", "1.875rem"],
+      ["leading-heading-md", "1.625rem"],
+      ["leading-heading-sm", "1.5rem"],
+      ["leading-body-lg", "1.625rem"],
+      ["leading-body", "1.375rem"],
+      ["leading-body-sm", "1.25rem"],
+      ["leading-caption", "1.125rem"],
+      ["leading-code-md", "1.25rem"],
+      ["leading-code-sm", "1.125rem"],
+      ["tracking-display", "-0.02em"],
+      ["tracking-heading", "-0.01em"],
+      ["tracking-body", "0em"],
+      ["tracking-caption", "0.01em"],
+      ["tracking-code", "0em"],
+    ];
+
+    for (const [token, expected] of expectedTypographyTokens) {
+      const match = tokensCss.match(new RegExp(`--${token}:\\s*([^;]+);`));
+      expect(match?.[1]?.trim()).toBe(expected);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- migrate root font loading to Inter + JetBrains Mono variable fonts via `next/font/google` with `latin`/`latin-ext` subsets and `display: swap`
- wire typography font variables to token aliases and add a base typographic reset in `globals.css` for headings, body copy, lists, and code primitives
- add Storybook typography scale documentation and token verification coverage to ensure typography values stay aligned with `design-system.md` spec

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm test:contrast`

## Follow-up evidence
- [ ] attach Storybook typography page screenshots in dark and light themes
- [ ] include Lighthouse note confirming no CLS regression from font loading

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive typography guidance and design system documentation for typography scale with visual examples.

* **Style**
  * Updated default fonts to Inter (sans-serif) and JetBrains Mono (monospace) with improved global typography styling.
  * Applied consistent styling to headings, paragraphs, lists, and code elements across the application.

* **Tests**
  * Added typography token validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->